### PR TITLE
Usability improvements of the terminal and ui scale

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -44,7 +44,7 @@ _global_script_class_icons={
 
 [application]
 
-config/name="Resoto-wasm-prototype"
+config/name="resoto-ui"
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.png"
 

--- a/src/scripts/autoloads/saveload_settings.gd
+++ b/src/scripts/autoloads/saveload_settings.gd
@@ -28,19 +28,19 @@ func load_settings() -> void:
 	if disabled:
 		return
 	var settings = load_settings_file()
-	API.psk = settings.psk
-	_g.ui_shrink = settings.ui_shrink
-	emit_signal("settings_loaded")
+	API.psk = settings[0].psk
+	_g.ui_shrink = settings[0].ui_shrink
+	emit_signal("settings_loaded", settings[1])
 
 
-func load_settings_file() ->Dictionary:
+func load_settings_file() -> Array:
 	if disabled:
-		return clear_settings()
+		return [clear_settings(), false]
 	var settings = File.new()
 	var settings_path = SETTINGS_FILE_NAME
 	
 	if not settings.file_exists(settings_path):
-		return clear_settings()
+		return [clear_settings(), false]
 	
 	settings.open_encrypted_with_pass(settings_path, File.READ, ENC)
 	var settings_data = clear_settings()
@@ -50,7 +50,7 @@ func load_settings_file() ->Dictionary:
 			if settings_var.has(key):
 				settings_data[key] = settings_var[key]
 	settings.close()
-	return settings_data
+	return [settings_data, true]
 
 
 func save_settings() -> void:

--- a/src/scripts/ui_main.gd
+++ b/src/scripts/ui_main.gd
@@ -6,7 +6,16 @@ func _ready() -> void:
 	SaveLoadSettings.load_settings()
 	
 	
-func show_connect_popup() -> void:
+func show_connect_popup(_found_settings:bool) -> void:
+	if !_found_settings:
+		var dpi:int = OS.get_screen_dpi()
+		if dpi >= 130:
+			_g.ui_shrink = 2.0
+		elif dpi >= 90:
+			_g.ui_shrink = 1.5
+		elif dpi >= 70:
+			_g.ui_shrink = 1.0
+		SaveLoadSettings.save_settings()
 	_g.popup_manager.open_popup("ConnectPopup")
 	
 	# If we ever need Godot to receive URL parameters:


### PR DESCRIPTION
- Automatic UI scaling by client dpi (educated guess) when no settings file is found

**Fixed minor usability issues with the terminal**
- CTRL+C clears line and adds old command line content greyed out to the terminal
- If there was no content in the command line, ^C will be added to the terminal
- No defocusing when copying content in the terminal
- Mac Command key was added to the modifier keys