### PR TITLE
Fix wrong event and context when creating new datasource from template

### DIFF
--- a/src/components/dashboard/new_widget_popup/new_widget_popup.gd
+++ b/src/components/dashboard/new_widget_popup/new_widget_popup.gd
@@ -334,7 +334,7 @@ func _on_AddDataSource(template_id:int= -1) -> void:
 		event = Analytics.EventsDatasource.NEW_FROM_TEMPLATE
 		context["template"] = template_options.get_child(template_id).text
 
-	Analytics.event(Analytics.EventsDatasource.NEW, {"widget" : ds.widget.wdiget_type_id})
+	Analytics.event(event, context)
 
 
 func delete_datasource(_data_source:Node) -> void:

--- a/src/components/dashboard/new_widget_popup/new_widget_popup.tscn
+++ b/src/components/dashboard/new_widget_popup/new_widget_popup.tscn
@@ -30,7 +30,6 @@ shadow_size = 10
 shadow_offset = Vector2( 0, 4 )
 
 [node name="NewWidgetPopup" instance=ExtResource( 1 )]
-visible = false
 margin_right = 800.0
 margin_bottom = 600.0
 script = ExtResource( 4 )


### PR DESCRIPTION
The code was using the same event a context of new datasources.