### PR TITLE
Fix bug that caused the new datasource fields to be invisible sometimes

### DIFF
--- a/src/components/dashboard/new_widget_popup/new_widget_popup.gd
+++ b/src/components/dashboard/new_widget_popup/new_widget_popup.gd
@@ -279,6 +279,8 @@ func _on_NewWidgetPopup_about_to_show() -> void:
 	
 	if widget_to_edit != null:
 		update_preview()
+		
+	update_new_data_vis()
 
 func _on_AddDataSource_pressed() -> void:
 	if data_source_container.get_child_count() >= preview_widget.max_data_sources:


### PR DESCRIPTION
Fixes a bug that, When creating a widget with maximum 1 datasource, and then trying to create another, the "New¨ datasource button and related fields remained invisible.
