### PR TITLE
Delete datasources when the widget or the data source container that holds its reference is deleted

### DIFF
--- a/src/components/dashboard/container/widget_container.gd
+++ b/src/components/dashboard/container/widget_container.gd
@@ -507,3 +507,8 @@ func _on_PanelContainer_mouse_entered():
 func _on_PanelContainer_mouse_exited():
 	if not is_maximized:
 		maximize_button.modulate.a = 0.0
+
+
+func _on_WidgetContainer_tree_exiting():
+	for data_source in data_sources:
+		data_source.queue_free()

--- a/src/components/dashboard/container/widget_container.tscn
+++ b/src/components/dashboard/container/widget_container.tscn
@@ -461,6 +461,7 @@ script = ExtResource( 3 )
 script = ExtResource( 4 )
 
 [connection signal="moved_or_resized" from="." to="." method="_on_WidgetContainer_moved_or_resized"]
+[connection signal="tree_exiting" from="." to="." method="_on_WidgetContainer_tree_exiting"]
 [connection signal="pressed" from="QueryWarning/VBox/PanelContainer/VBox/ConfigButton" to="." method="_on_ConfigButton_pressed"]
 [connection signal="mouse_entered" from="PanelContainer" to="." method="_on_PanelContainer_mouse_entered"]
 [connection signal="mouse_exited" from="PanelContainer" to="." method="_on_PanelContainer_mouse_exited"]

--- a/src/components/dashboard/new_widget_popup/data_source_container.gd
+++ b/src/components/dashboard/new_widget_popup/data_source_container.gd
@@ -313,3 +313,7 @@ func _on_FunctionLineEdit_text_entered(new_text):
 func _on_FunctionAlias_text_entered(new_text):
 	data_source.function_alias = new_text
 	update_query()
+
+
+func _on_DatasourceContainer_tree_exiting():
+	data_source.queue_free()

--- a/src/components/dashboard/new_widget_popup/data_source_container.tscn
+++ b/src/components/dashboard/new_widget_popup/data_source_container.tscn
@@ -427,6 +427,7 @@ margin_bottom = 826.0
 mouse_filter = 2
 custom_styles/panel = SubResource( 2 )
 
+[connection signal="tree_exiting" from="." to="." method="_on_DatasourceContainer_tree_exiting"]
 [connection signal="toggled" from="VBoxContainer/HBoxContainer/ExpandButton" to="." method="_on_ExpandButton_toggled"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/DeleteButton" to="." method="_on_DeleteButton_pressed"]
 [connection signal="option_changed" from="VBoxContainer/DatasourceSettings/MetricsVBox/MetricsOptions" to="." method="_on_MetricsOptions_option_changed"]

--- a/src/components/dashboard/new_widget_popup/new_widget_popup.gd
+++ b/src/components/dashboard/new_widget_popup/new_widget_popup.gd
@@ -113,6 +113,8 @@ func _on_AddWidgetButton_pressed() -> void:
 		
 	Analytics.event(event, {"widget" : widget.widget_type_id})
 	
+	
+	clear_data_sources()
 	preview_widget.queue_free()
 
 
@@ -254,12 +256,16 @@ func _on_get_config_id_done(_error, _response, _config_key) -> void:
 		ds.set_metrics(metrics)
 
 
-func _on_NewWidgetPopup_about_to_show() -> void:
-	widget_name_label.text = ""
-	
+func clear_data_sources():
 	for data_source in data_source_container.get_children():
 		data_source_container.remove_child(data_source)
 		data_source.queue_free()
+
+
+func _on_NewWidgetPopup_about_to_show() -> void:
+	widget_name_label.text = ""
+	
+	clear_data_sources()
 	
 	if widget_to_edit != null:
 		widget_name_label.text = widget_to_edit.title


### PR DESCRIPTION
There were some data sources kept alive in the back that should have been freed. 
This also caused bugs that under some circumstances, they would query and fail because the widget that they had assigned (specifically the preview widget in the add widget dialog) was freed before.