### PR TITLE
[docker][fix] create git-commit file in ui directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN /build/godot/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux_headless.64 --pa
 # Upload resotoui
 RUN if [ -n "$SPACES_NAME" ]; then resoto-ui-upload --verbose; fi
 
-RUN echo "${SOURCE_COMMIT:-unknown}" > /usr/local/etc/git-commit.HEAD
+RUN echo "${SOURCE_COMMIT:-unknown}" > /usr/local/resoto/ui/git-commit.HEAD
 
 # Setup main image
 FROM ubuntu:20.04


### PR DESCRIPTION
This now creates the git-commit.HEAD file, which contains the long sha of the current git commit, inside the directory which is later copied into the Resoto Docker container.