### PR TITLE
[docker][fix] Create git-commit file before upload

### DIFF
--- a/.github/workflows/test-export.yml
+++ b/.github/workflows/test-export.yml
@@ -22,6 +22,9 @@ jobs:
           relative_project_path: ./src
           relative_export_path: ./builds
           archive_output: false
+      - name: create git sha file
+        run: |
+          echo ${{ github.sha }} > ./builds/HTML5/git-commit.HEAD
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,11 @@ WORKDIR /usr/local/resoto/ui
 COPY src /usr/src/ui
 RUN /build/godot/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux_headless.64 --path /usr/src/ui --export HTML5 /usr/local/resoto/ui/index.html
 
+RUN echo "${SOURCE_COMMIT:-unknown}" > /usr/local/resoto/ui/git-commit.HEAD
+
 # Upload resotoui
 RUN if [ -n "$SPACES_NAME" ]; then resoto-ui-upload --verbose; fi
 
-RUN echo "${SOURCE_COMMIT:-unknown}" > /usr/local/resoto/ui/git-commit.HEAD
 
 # Setup main image
 FROM ubuntu:20.04


### PR DESCRIPTION
Currently the hash is only available in the docker image. This includes it in the uploaded UI as well and also creates the same file for test exports.