### PR TITLE
Show grid above lines

### DIFF
--- a/src/components/dashboard/widget_chart/widget_chart.tscn
+++ b/src/components/dashboard/widget_chart/widget_chart.tscn
@@ -15,7 +15,8 @@ void fragment(){
 	vec2 px_size = 1.0/size;
 	vec2 coord = fract((UV - vec2(0.0, zero_position)) * grid_divisions);
 	vec2 step_width = 1.0 - (px_size * line_width * grid_divisions);
-	COLOR = grid_color * clamp(step(step_width.y, coord.y) + step(step_width.x, coord.x) + step(step_width.y, abs(1.0-coord.y)) + step(step_width.x, abs(1.0-coord.x)), 0.0, 1.0);
+	COLOR = grid_color;
+	COLOR.a *= clamp(step(step_width.y, coord.y) + step(step_width.x, coord.x) + step(step_width.y, abs(1.0-coord.y)) + step(step_width.x, abs(1.0-coord.x)), 0.0, 1.0);
 }"
 
 [sub_resource type="ShaderMaterial" id=6]
@@ -114,6 +115,7 @@ default_color = Color( 0.537255, 0.819608, 0.945098, 0.470588 )
 texture_mode = 2
 
 [node name="GraphArea" type="Control" parent="Viewport/GridContainer/Grid"]
+show_behind_parent = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_clip_content = true


### PR DESCRIPTION
Small change to show the grid above the line charts. 
Without this change, it looks like this:
![imagen](https://user-images.githubusercontent.com/46932830/201093129-1417b78a-2288-4f57-9a80-b123f74c84ce.png)
(Note how the grid is only visible behind the top most lines)

With the change, it will look like this:
![imagen](https://user-images.githubusercontent.com/46932830/201093258-e9cda734-c319-4f46-adbc-9985b850236f.png)

