### PR TITLE
Wait a frame to get the popup size

### DIFF
--- a/src/components/toast/component_toast_manager.gd
+++ b/src/components/toast/component_toast_manager.gd
@@ -30,6 +30,7 @@ func on_add_toast(_title:String, _description:String=description, _status:int=st
 	
 	toast.connect("closed", self, "on_toast_closed", [toast], 4)
 	toast.open(_title, _description, _status, _duration, _is_closable)
+	yield(VisualServer,"frame_post_draw")
 	toast.rect_position = Vector2(-toast.rect_size.x - toast_padding, -toast.rect_size.y - toast_padding)
 	
 	_g.emit_signal("toast_created", toast)


### PR DESCRIPTION
Some toasts don't show completely due to the `rect_size` not being updated when used to compute the position.
Without this change it sometimes looks like this:
![imagen](https://user-images.githubusercontent.com/46932830/201097318-d82bfe9d-9cad-4f68-b43a-4c6030a0362f.png)

With the change, it looks like this:
![imagen](https://user-images.githubusercontent.com/46932830/201097422-9a5a4c41-2f2f-42d9-af0c-3beb844e916a.png)
