### PR TITLE
Start Watchdog on ready

### DIFF
--- a/src/html_shell/godot.html
+++ b/src/html_shell/godot.html
@@ -224,13 +224,19 @@
 		// A simple Godot watchdog to notify the user when the engine is unresponsive
 		var godotWatchdogTimer = 0.0;
 		var godotWatchdogDialog = false;
-		var myInterval = setInterval(godotWatchdogCount, 500);
+		var godotWatchdogInterval;
 		var focusTime = 0.0;
 		var unfocusTime = 0.0;
 		var totalTime = 0.0;
 
 		const oneHourEvent = new Event("oneHourEvent");
 		var oneHourInterval = setInterval( () => {dispatchEvent(oneHourEvent)}, 3600000);
+
+		function godotWatchdogStart() {
+			if (!godotWatchdogInterval) {
+				godotWatchdogInterval = setInterval(godotWatchdogCount, 500)
+			}
+		}
 
 		function godotWatchdogCount() {
 			if (document.hasFocus())

--- a/src/scripts/tools/html_helpers.gd
+++ b/src/scripts/tools/html_helpers.gd
@@ -33,6 +33,8 @@ func _ready():
 	_g.os = JavaScript.eval("getOS()")
 	if _g.os == "MacOS" and not InputMap.has_action("mac_copy"):
 		add_mac_actions()
+	
+	JavaScript.eval("godotWatchdogStart()")
 
 
 func _physics_process(delta:float):


### PR DESCRIPTION
The JS watchdog was started with loading the page, if the UI wasm loaded longer than the 3s of the watchdog, the user would get an unresponsive alert before the UI could even start.