### PR TITLE
Fix watchdog alert on refocus

### DIFF
--- a/src/html_shell/godot.html
+++ b/src/html_shell/godot.html
@@ -245,6 +245,7 @@
 				focusTime += 0.5;
 			} else {
 				unfocusTime += 0.5;
+				godotWatchdogTimer = 0.0;
 			}
 
 			totalTime += 0.5;


### PR DESCRIPTION
When the window lost focus, godot was not updating the watchdog alert (because the thread freezes when the tab is not in focus). This lead to a bug where you would always get a watchdog alert on refocus.