### PR TITLE
Refactor tables

### DIFF
--- a/src/components/dashboard/data_sources/data_source_text_search.gd
+++ b/src/components/dashboard/data_sources/data_source_text_search.gd
@@ -21,23 +21,20 @@ func make_query(dashboard_filters : Dictionary, _attr : Dictionary):
 	if dashboard_filters["account"] != "" and dashboard_filters["account"] != "All":
 		global_filters += " and /ancestors.account.reported.name=\"%s\"" % dashboard_filters["account"]
 	q = q.replace("{global_filters}", global_filters)
-	set_request(API.cli_execute(q, self))
+	set_request(API.graph_search(q, self, "list"))
 
 
-func _on_cli_execute_done(_error : int, response):
+func _on_graph_search_done(_error : int, response):
 	if _error:
 		emit_signal("query_status", FAILED, "Invalid Full Text Search", "There is a problem with the search query.")
 		return
-	var result : String = response.transformed.result
+	var result : Array = response.transformed.result
 	if "Error: " in response.transformed.result:
 		_g.emit_signal("add_toast", "Invalid query", result, 1, self)
 		emit_signal("query_status", FAILED, "Invalid query", result)
 		return
 	if is_instance_valid(widget):
-		result = result.trim_suffix("\n")
 		widget.set_data(result, type)
-		if result.find("\n") < 0:
-			_g.emit_signal("add_toast", "Empty result", "The query result has no data.", 2, self)
 		emit_signal("query_status", OK, "")
 
 	
@@ -65,9 +62,9 @@ func update_query():
 	if filters != "":
 		query += " and %s" % filters
 		
-	query += " | list --csv %s" % list
+#	query += " | list --csv %s" % list
 		
-	query = "search " + query
+#	query = "search " + query
 
 
 func get_data() -> Dictionary:

--- a/src/components/dashboard/new_widget_popup/data_source_container.gd
+++ b/src/components/dashboard/new_widget_popup/data_source_container.gd
@@ -172,7 +172,7 @@ func _on_QueryEdit_focus_exited():
 
 func _on_QueryEdit_item_rect_changed():
 	var row_count = query_edit.get_total_visible_rows()
-	query_edit.rect_min_size.y = (row_count*25)+10
+	query_edit.rect_min_size.y = max((row_count*25)+10, 36)
 
 func execute_query_edit():
 	data_source.query = query_edit.text

--- a/src/components/dashboard/new_widget_popup/data_source_container.tscn
+++ b/src/components/dashboard/new_widget_popup/data_source_container.tscn
@@ -105,108 +105,108 @@ icon_tex = ExtResource( 4 )
 visible = false
 margin_top = 37.0
 margin_right = 511.0
-margin_bottom = 448.0
+margin_bottom = 435.0
 size_flags_horizontal = 3
 
 [node name="MetricsVBox" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
 margin_right = 511.0
-margin_bottom = 47.0
+margin_bottom = 45.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/MetricsVBox"]
 margin_right = 511.0
-margin_bottom = 21.0
+margin_bottom = 20.0
 text = "Metric"
 
 [node name="MetricsOptions" parent="VBoxContainer/DatasourceSettings/MetricsVBox" instance=ExtResource( 9 )]
-margin_top = 22.0
+margin_top = 21.0
 margin_right = 511.0
-margin_bottom = 47.0
+margin_bottom = 45.0
 
 [node name="FunctionVBox" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 51.0
+margin_top = 49.0
 margin_right = 511.0
-margin_bottom = 98.0
+margin_bottom = 94.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/FunctionVBox"]
 margin_right = 511.0
-margin_bottom = 21.0
+margin_bottom = 20.0
 text = "Aggregator"
 
 [node name="FunctionComboBox" parent="VBoxContainer/DatasourceSettings/FunctionVBox" instance=ExtResource( 9 )]
-margin_top = 22.0
+margin_top = 21.0
 margin_right = 511.0
-margin_bottom = 47.0
+margin_bottom = 45.0
 items = [ "", "sum", "min", "max", "avg", "count", "sum_over_time", "min_over_time", "max_over_time", "avg_over_time", "count_over_time" ]
 
 [node name="FilterHBox" type="HBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 102.0
+margin_top = 98.0
 margin_right = 511.0
-margin_bottom = 197.0
+margin_bottom = 191.0
 
 [node name="FilterWidget" parent="VBoxContainer/DatasourceSettings/FilterHBox" instance=ExtResource( 1 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_right = 511.0
-margin_bottom = 95.0
+margin_bottom = 93.0
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 201.0
+margin_top = 195.0
 margin_right = 511.0
-margin_bottom = 256.0
+margin_bottom = 248.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/VBoxContainer"]
 margin_right = 511.0
-margin_bottom = 21.0
+margin_bottom = 20.0
 text = "Date Offset"
 
 [node name="DateOffsetLineEdit" type="LineEdit" parent="VBoxContainer/DatasourceSettings/VBoxContainer"]
-margin_top = 22.0
+margin_top = 21.0
 margin_right = 511.0
-margin_bottom = 55.0
+margin_bottom = 53.0
 script = ExtResource( 6 )
 
 [node name="VBoxContainer4" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 260.0
+margin_top = 252.0
 margin_right = 511.0
-margin_bottom = 315.0
+margin_bottom = 305.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/VBoxContainer4"]
 margin_right = 511.0
-margin_bottom = 21.0
+margin_bottom = 20.0
 text = "Sum by"
 
 [node name="ByLineEdit" type="LineEdit" parent="VBoxContainer/DatasourceSettings/VBoxContainer4"]
-margin_top = 22.0
+margin_top = 21.0
 margin_right = 511.0
-margin_bottom = 55.0
+margin_bottom = 53.0
 script = ExtResource( 6 )
 
 [node name="VBoxContainer5" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 319.0
+margin_top = 309.0
 margin_right = 511.0
-margin_bottom = 374.0
+margin_bottom = 362.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/VBoxContainer5"]
 margin_right = 511.0
-margin_bottom = 21.0
+margin_bottom = 20.0
 text = "Legend"
 
 [node name="LegendEdit" type="LineEdit" parent="VBoxContainer/DatasourceSettings/VBoxContainer5"]
-margin_top = 22.0
+margin_top = 21.0
 margin_right = 511.0
-margin_bottom = 55.0
+margin_bottom = 53.0
 script = ExtResource( 6 )
 
 [node name="StackedCheckBox" type="CheckBox" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 378.0
+margin_top = 366.0
 margin_right = 511.0
-margin_bottom = 411.0
+margin_bottom = 398.0
 pressed = true
 text = "Stacked"
 
@@ -214,30 +214,30 @@ text = "Stacked"
 visible = false
 margin_top = 37.0
 margin_right = 511.0
-margin_bottom = 293.0
+margin_bottom = 226.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TextSearchSettings"]
 margin_right = 511.0
-margin_bottom = 21.0
+margin_bottom = 20.0
 size_flags_horizontal = 3
 text = "Text"
 
 [node name="TextLineEdit" type="LineEdit" parent="VBoxContainer/TextSearchSettings"]
-margin_top = 25.0
+margin_top = 24.0
 margin_right = 511.0
-margin_bottom = 58.0
+margin_bottom = 56.0
 size_flags_horizontal = 3
 script = ExtResource( 6 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TextSearchSettings"]
-margin_top = 62.0
+margin_top = 60.0
 margin_right = 511.0
-margin_bottom = 95.0
+margin_bottom = 93.0
 
 [node name="Label2" type="Label" parent="VBoxContainer/TextSearchSettings/HBoxContainer"]
 margin_top = 6.0
 margin_right = 235.0
-margin_bottom = 27.0
+margin_bottom = 26.0
 size_flags_horizontal = 3
 text = "Kinds"
 
@@ -254,33 +254,35 @@ icon_tex = ExtResource( 5 )
 icon_margin = 5
 
 [node name="LineEditKinds" type="LineEdit" parent="VBoxContainer/TextSearchSettings"]
-margin_top = 99.0
+margin_top = 97.0
 margin_right = 511.0
-margin_bottom = 132.0
+margin_bottom = 129.0
 script = ExtResource( 6 )
 
 [node name="Label2" type="Label" parent="VBoxContainer/TextSearchSettings"]
-margin_top = 136.0
+margin_top = 133.0
 margin_right = 511.0
-margin_bottom = 157.0
+margin_bottom = 153.0
 text = "Filters"
 
 [node name="TextFiltersLineEdit" type="LineEdit" parent="VBoxContainer/TextSearchSettings"]
-margin_top = 161.0
+margin_top = 157.0
 margin_right = 511.0
-margin_bottom = 194.0
+margin_bottom = 189.0
 script = ExtResource( 6 )
 
 [node name="Label3" type="Label" parent="VBoxContainer/TextSearchSettings"]
-margin_top = 198.0
+visible = false
+margin_top = 193.0
 margin_right = 511.0
-margin_bottom = 219.0
+margin_bottom = 213.0
 text = "List"
 
 [node name="ListLineEdit" type="LineEdit" parent="VBoxContainer/TextSearchSettings"]
-margin_top = 223.0
+visible = false
+margin_top = 217.0
 margin_right = 511.0
-margin_bottom = 256.0
+margin_bottom = 249.0
 script = ExtResource( 6 )
 
 [node name="TwoEntryAggregateSettings" type="VBoxContainer" parent="VBoxContainer"]

--- a/src/components/dashboard/new_widget_popup/data_source_container.tscn
+++ b/src/components/dashboard/new_widget_popup/data_source_container.tscn
@@ -105,12 +105,12 @@ icon_tex = ExtResource( 4 )
 visible = false
 margin_top = 37.0
 margin_right = 511.0
-margin_bottom = 435.0
+margin_bottom = 453.0
 size_flags_horizontal = 3
 
 [node name="MetricsVBox" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
 margin_right = 511.0
-margin_bottom = 45.0
+margin_bottom = 54.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/MetricsVBox"]
@@ -121,12 +121,13 @@ text = "Metric"
 [node name="MetricsOptions" parent="VBoxContainer/DatasourceSettings/MetricsVBox" instance=ExtResource( 9 )]
 margin_top = 21.0
 margin_right = 511.0
-margin_bottom = 45.0
+margin_bottom = 54.0
+rect_min_size = Vector2( 100, 33 )
 
 [node name="FunctionVBox" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 49.0
+margin_top = 58.0
 margin_right = 511.0
-margin_bottom = 94.0
+margin_bottom = 112.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/FunctionVBox"]
@@ -137,13 +138,14 @@ text = "Aggregator"
 [node name="FunctionComboBox" parent="VBoxContainer/DatasourceSettings/FunctionVBox" instance=ExtResource( 9 )]
 margin_top = 21.0
 margin_right = 511.0
-margin_bottom = 45.0
+margin_bottom = 54.0
+rect_min_size = Vector2( 100, 33 )
 items = [ "", "sum", "min", "max", "avg", "count", "sum_over_time", "min_over_time", "max_over_time", "avg_over_time", "count_over_time" ]
 
 [node name="FilterHBox" type="HBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 98.0
+margin_top = 116.0
 margin_right = 511.0
-margin_bottom = 191.0
+margin_bottom = 209.0
 
 [node name="FilterWidget" parent="VBoxContainer/DatasourceSettings/FilterHBox" instance=ExtResource( 1 )]
 anchor_right = 0.0
@@ -153,9 +155,9 @@ margin_bottom = 93.0
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 195.0
+margin_top = 213.0
 margin_right = 511.0
-margin_bottom = 248.0
+margin_bottom = 266.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/VBoxContainer"]
@@ -170,9 +172,9 @@ margin_bottom = 53.0
 script = ExtResource( 6 )
 
 [node name="VBoxContainer4" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 252.0
+margin_top = 270.0
 margin_right = 511.0
-margin_bottom = 305.0
+margin_bottom = 323.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/VBoxContainer4"]
@@ -187,9 +189,9 @@ margin_bottom = 53.0
 script = ExtResource( 6 )
 
 [node name="VBoxContainer5" type="VBoxContainer" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 309.0
+margin_top = 327.0
 margin_right = 511.0
-margin_bottom = 362.0
+margin_bottom = 380.0
 custom_constants/separation = 1
 
 [node name="Label" type="Label" parent="VBoxContainer/DatasourceSettings/VBoxContainer5"]
@@ -204,9 +206,9 @@ margin_bottom = 53.0
 script = ExtResource( 6 )
 
 [node name="StackedCheckBox" type="CheckBox" parent="VBoxContainer/DatasourceSettings"]
-margin_top = 366.0
+margin_top = 384.0
 margin_right = 511.0
-margin_bottom = 398.0
+margin_bottom = 416.0
 pressed = true
 text = "Stacked"
 
@@ -236,17 +238,19 @@ margin_bottom = 93.0
 
 [node name="Label2" type="Label" parent="VBoxContainer/TextSearchSettings/HBoxContainer"]
 margin_top = 6.0
-margin_right = 235.0
+margin_right = 253.0
 margin_bottom = 26.0
 size_flags_horizontal = 3
 text = "Kinds"
 
 [node name="KindsComboBox" parent="VBoxContainer/TextSearchSettings/HBoxContainer" instance=ExtResource( 9 )]
-margin_left = 239.0
-margin_right = 474.0
+margin_left = 257.0
+margin_right = 511.0
+rect_min_size = Vector2( 100, 33 )
 size_flags_horizontal = 3
 
 [node name="Add" parent="VBoxContainer/TextSearchSettings/HBoxContainer" instance=ExtResource( 10 )]
+visible = false
 margin_left = 478.0
 margin_right = 511.0
 hint_tooltip = "Add Kind"
@@ -397,7 +401,7 @@ script = ExtResource( 6 )
 [node name="QueryEditVBox" type="VBoxContainer" parent="VBoxContainer"]
 margin_top = 37.0
 margin_right = 511.0
-margin_bottom = 127.0
+margin_bottom = 133.0
 
 [node name="QueryLabel" type="Label" parent="VBoxContainer/QueryEditVBox"]
 margin_right = 511.0
@@ -407,16 +411,16 @@ text = "Query"
 [node name="QueryEdit" type="TextEdit" parent="VBoxContainer/QueryEditVBox"]
 margin_top = 24.0
 margin_right = 511.0
-margin_bottom = 54.0
-rect_min_size = Vector2( 0, 30 )
+margin_bottom = 60.0
+rect_min_size = Vector2( 0, 36 )
 wrap_enabled = true
 caret_blink = true
 
 [node name="QueryUpdateButton" type="Button" parent="VBoxContainer/QueryEditVBox"]
 margin_left = 389.667
-margin_top = 58.0
+margin_top = 64.0
 margin_right = 511.0
-margin_bottom = 90.0
+margin_bottom = 96.0
 size_flags_horizontal = 8
 size_flags_vertical = 0
 text = "Update Query"

--- a/src/components/dashboard/new_widget_popup/new_widget_popup.gd
+++ b/src/components/dashboard/new_widget_popup/new_widget_popup.gd
@@ -267,6 +267,7 @@ func clear_data_sources():
 
 func _on_NewWidgetPopup_about_to_show() -> void:
 	widget_name_label.text = ""
+	$"%WidgetPreviewTitleLabel".text = ""
 	clear_data_sources()
 	if widget_to_edit != null:
 		current_widget_preview_name = widget_to_edit.widget.widget_type_id

--- a/src/components/dashboard/widget_table/widget_table.gd
+++ b/src/components/dashboard/widget_table/widget_table.gd
@@ -33,7 +33,7 @@ var current_page:int = 0
 
 var data_source_type : int
 
-var headers_array : Array = []
+var headers_array : PoolStringArray = []
 
 onready var table = $Table
 onready var header_row := $Table/ScrollContainer/TableVBox/Header
@@ -312,15 +312,13 @@ func set_header_color(_new_color:Color):
 
 func get_csv(sepparator := ",", end_of_line := "\n") -> String:
 	var csv_array : PoolStringArray = []
-	var header_array : PoolStringArray = []
-	for i in range(1, header_row.get_child_count()):
-		header_array.append('"%s"' % header_row.get_child(i).text)
+
+	csv_array.append(headers_array.join(sepparator))
 	
-	csv_array.append(header_array.join(sepparator))
-	
-	for i in range(0, raw_data.size()):
-		var row = raw_data[i] as PoolStringArray
-		row.remove(0)
+	for data in raw_data:
+		var row : PoolStringArray = []
+		for i in headers_array.size():
+			row.append('"%s"' % str(get_value(data, i)))
 		csv_array.append(row.join(sepparator))
 		
 	return csv_array.join(end_of_line)
@@ -337,12 +335,14 @@ func get_data_count(data : Dictionary) -> int:
 	
 func get_value(data : Dictionary, index : int):
 	if data_source_type == DataSource.TYPES.AGGREGATE_SEARCH:
-		var group_keys : Array = data["group"].keys()
+		var keys : Array = data["group"].keys()
+		var group_keys : Array = keys.duplicate()
+		var all_keys : Array = data.keys()
+		all_keys.erase("group")
+		keys.append_array(all_keys)
 		if index < group_keys.size():
 			return data["group"][group_keys[index]]
-			
-		index = index - group_keys.size() + 1
-		return data[data.keys()[index]]
+		return data[keys[index]]
 	elif data_source_type == DataSource.TYPES.SEARCH:
 		var key : String = DefaultSearchAttributes.keys()[index]
 		var path : Array = DefaultSearchAttributes[key]

--- a/src/components/dashboard/widget_table/widget_table.gd
+++ b/src/components/dashboard/widget_table/widget_table.gd
@@ -20,6 +20,10 @@ var max_allowed_rows:int = 30
 var page_count:int = 0
 var current_page:int = 0
 
+var data_source_type : int
+var list_sepparator : String
+var remove_prefix : String
+
 onready var table = $Table
 onready var header_row := $Table/ScrollContainer/TableVBox/Header
 onready var rows := $Table/ScrollContainer/TableVBox/ScrollContainer/Rows
@@ -55,14 +59,27 @@ func set_headers(headers : Array):
 		c_id += 1
 
 
-func add_row(data : Array):
+func add_row(data):
 	var row = HBoxContainer.new()
 	row.set("custom_constants/separation", 0)
 	row.size_flags_vertical = SIZE_EXPAND_FILL
 	var c_id:= 0
 	var r_count:= rows.get_child_count()
 	rows.add_child(row)
-	for value in data:
+	
+	var n := 0
+	
+	if data_source_type == DataSource.TYPES.AGGREGATE_SEARCH:
+		n = data['group'].keys().size() + data.keys().size() - 1
+	elif data_source_type == DataSource.TYPES.SEARCH:
+		n = get_data_count(data)
+	
+	for i in n:
+		var value
+		if data_source_type == DataSource.TYPES.AGGREGATE_SEARCH:
+			value = get_aggregate_value(data, i)
+		elif data_source_type == DataSource.TYPES.SEARCH:
+			value = get_data_slice(data, i)
 		var is_header_column:bool = c_id <= header_columns_count
 		var color:Color = column_header_color if is_header_column else row_color
 		var table_cell = TableCell.instance()
@@ -105,62 +122,50 @@ func set_data(data, type):
 		raw_data.clear()
 	clear_all()
 	
+	data_source_type = type
+	
 	if type == DataSource.TYPES.AGGREGATE_SEARCH:
-		table.margin_bottom = 0
-		pagination.hide()
+		
+		raw_data = data
 		var headers : Array = data[0]["group"].keys()
 		var vars : Array = data[0].keys()
 		vars.remove(vars.find("group"))
 		headers.append_array(vars)
 		set_headers(headers)
 		
-		for data_row in data:
-			var data_array : Array = []#[" "]
-			for key in data_row["group"]:
-				data_array.append(data_row["group"][key])
-				
-			for key in data_row:
-				if key == "group":
-					continue
-				data_array.append(data_row[key])
-			
-			raw_data.append(data_array)
-	
 	elif type == DataSource.TYPES.SEARCH:
-		var rows_array : Array = data.split("\n",false)
-		set_headers(rows_array[0].split(",",false))
-		rows_array.remove(0)
-		
-		var n : float = rows_array.size()
-		
-		raw_data.resize(rows_array.size())
-		
-		page_count = int(ceil(n / max_allowed_rows))
-		if page_count > 1:
-			table.margin_bottom = -33
-			pagination.show()
-			pagination.max_value = max(0, page_count)
-			pagination.suffix = "of %d" % pagination.max_value
-			pagination.value = 1
-			current_page = 0
+		raw_data = data.split("\n")
+		if '","' in raw_data[0]:
+			list_sepparator = '",'
+			remove_prefix = '"'
+		elif "|" in raw_data[0]:
+			list_sepparator = "|"
+			remove_prefix = ""
+			raw_data.remove(1)
 		else:
-			table.margin_bottom = 0
-			pagination.hide()
+			list_sepparator = ", "
+			remove_prefix = ""
+		var headers = raw_data[0].split(list_sepparator,true)
+		raw_data.remove(0)
+		set_headers(headers)
 		
-		if not rows_array.empty():
-		
-			var tmp_array : PoolStringArray = []
-			var cells_count = rows_array[0].count(",") + 1
-			tmp_array.resize(cells_count)
-			
-			for i in rows_array.size():
-				raw_data[i] = tmp_array
-				for j in cells_count:
-					raw_data[i][j] = rows_array[i].get_slice(",", j)
-			
-	
+	update_page_count(raw_data.size())
 	yield(VisualServer, "frame_post_draw")
 	sort_by_column(sorting_column, sorting_type == "asc")
+
+
+func update_page_count(row_count : int):
+	page_count = int(ceil(float(row_count) / max_allowed_rows))
+	if page_count > 1:
+		table.margin_bottom = -33
+		pagination.show()
+		pagination.max_value = max(1, page_count)
+		pagination.suffix = "of %d" % pagination.max_value
+		current_page = 1
+		pagination.value = 1
+	else:
+		table.margin_bottom = 0
+		pagination.hide()
 
 
 func update_table():
@@ -178,15 +183,27 @@ func update_table():
 			
 	else:
 		for i in n:
-			var row = rows.get_child(i)
 			var k = i + max_allowed_rows * current_page
-			for j in raw_data[k].size():
-				var cell = row.get_child(j)
-				cell.cell_text = raw_data[k][j]
+			set_row(raw_data[k], i)
 		
 	update_delay_timer.stop()
 	_on_UpdateDelayTimer_timeout()
 
+
+func set_row(data, i):
+	if i <= rows.get_child_count():
+		var row = rows.get_child(i)
+		
+		if data_source_type == DataSource.TYPES.AGGREGATE_SEARCH:
+			var n = header_row.get_child_count()
+			for j in n:
+				row.get_child(j).cell_text = str(get_aggregate_value(data, j))
+		elif data_source_type == DataSource.TYPES.SEARCH:
+			var n = get_data_count(data)
+			for j in n:
+				row.get_child(j).cell_text = get_data_slice(data, j)
+	else:
+		add_row(data)
 
 func _on_Rows_resized():
 	if is_instance_valid(rows):
@@ -270,26 +287,56 @@ func sort_by_column(column : int, ascending : bool):
 			if header.column != column:
 				header.reset_sort()
 		sorting_column = column
-		if sorting_column > raw_data[0].size()-1:
-			sorting_column = raw_data[0].size()-1
-		if ascending:
-			raw_data.sort_custom(self, "sort_ascending")
-		else:
-			raw_data.sort_custom(self, "sort_descending")
+		
+		if data_source_type == DataSource.TYPES.AGGREGATE_SEARCH:
+			if sorting_column > header_row.get_child_count()-1:
+				sorting_column = header_row.get_child_count()-1
+		
+			if ascending:
+				raw_data.sort_custom(self, "sort_ascending")
+			else:
+				raw_data.sort_custom(self, "sort_descending")
+				
+		elif data_source_type == DataSource.TYPES.SEARCH:
+			var m = header_row.get_child_count() - 1
+			if sorting_column > m:
+				sorting_column = m
+		
+			if ascending:
+				raw_data.sort_custom(self, "sort_ascending_text")
+			else:
+				raw_data.sort_custom(self, "sort_descending_text")
+				
 	update_table()
 
 
 func sort_ascending(a, b):
-	if a[sorting_column] < b[sorting_column]:
-		return true
-	return false
+	var va = get_aggregate_value(a, sorting_column)
+	var vb = get_aggregate_value(b, sorting_column)
+	return va < vb
 
 
 func sort_descending(a, b):
-	if a[sorting_column] > b[sorting_column]:
+	var va = get_aggregate_value(a, sorting_column)
+	var vb = get_aggregate_value(b, sorting_column)
+	return va > vb
+
+
+func sort_ascending_text(a : String, b : String) -> bool:
+	var va : String = get_data_slice(a, sorting_column)
+	var vb : String = get_data_slice(b, sorting_column)
+	
+	if va.naturalnocasecmp_to(vb) < 0:
 		return true
 	return false
-
+	 
+func sort_descending_text(a : String, b : String) -> bool:
+	var va : String =  get_data_slice(a, sorting_column)
+	var vb : String =  get_data_slice(b, sorting_column)
+	
+	if va.naturalnocasecmp_to(vb) > 0:
+		return true
+	return false
 
 func set_column_header_color(_new_color:Color):
 	column_header_color = _new_color
@@ -330,5 +377,21 @@ func get_csv(sepparator := ",", end_of_line := "\n"):
 
 
 func _on_Pagination_value_changed(value):
-	current_page = value-1
+	current_page = value - 1
 	update_table()
+
+func get_data_slice(data : String, slice : int):
+	return data.get_slice(list_sepparator, slice).trim_prefix(remove_prefix)
+	
+	
+func get_data_count(data : String):
+	return min(data.count(list_sepparator) + 1, header_row.get_child_count())
+	
+	
+func get_aggregate_value(data : Dictionary, index : int):
+	var group_keys : Array = data["group"].keys()
+	if index < group_keys.size():
+		return data["group"][group_keys[index]]
+		
+	index = index - group_keys.size() + 1
+	return data[data.keys()[index]]


### PR DESCRIPTION
This PR changes how the tables are filled up. Code may be a bit more complex than before, but is more performant, and what is most important, now we font get memory pool issues for large search queries.

Before this PR, when a request was done, the datasource called the `set_data` function on the table. In there, the data was arranged into a Matrix (array of array) which was used to fill the table. This Array needed too many allocations to be filled in large searches and made Godot run out of memory allocation pools.

Right now, the table keeps the data as the request sent it. At the moment of writing it on the table, it just parses the data on the fly and write the text on the cell. This together with the pagination feature that was added before makes it a lot less memory hungry, and makes the memory pool limit a lot harder to reach.

The downside is that now we have to take care of each type of request (aggregate of search) separately in many places.

Tests i did (maybe we should redo them before merge):

- [x] Open a dashboard, open the dialog to create a new widget. Select a table.
- [x] Select aggregate datasource, make a query, check the table is populated correctly.
- [x] Play with filters and pages.
- [x] Delete the datasource, create a search one now.
- [x] Play with pages and filters again.
- [x] Accept the widget, test it on the dashboard.