### PR TITLE
Fix setting the tooltip width automatically

### DIFF
--- a/src/components/dashboard/widget_heatmap/widget_heatmap.gd
+++ b/src/components/dashboard/widget_heatmap/widget_heatmap.gd
@@ -94,7 +94,7 @@ func update_highlighted_cell(cell_position : Vector2):
 
 
 func set_tooltip_text(_text:String):
-	tooltip.get_node("Text").bbcode_text = _text
+	tooltip.get_node("Text").set_bbcode(_text)
 
 
 func set_low_color(new_color : Color):

--- a/src/components/shared/richtext_uniwidth_resize.gd
+++ b/src/components/shared/richtext_uniwidth_resize.gd
@@ -8,7 +8,7 @@ func set_bbcode(_new:String):
 
 func adjust_size() -> void:
 	var new_rect_min_size_x := 0.0
-	for line in bbcode_text.split("\n"):
+	for line in text.split("\n"):
 		new_rect_min_size_x = max(new_rect_min_size_x, get_font("normal_font").get_string_size(line).x)
 	rect_min_size.x = new_rect_min_size_x
 	rect_size.x = new_rect_min_size_x


### PR DESCRIPTION
Note that i also changed checking the size with `bbcode_text` to `text`, because using `bbcode_text` size also takes into account the size of the bbcode blocks... For example now looks like this:

![imagen](https://user-images.githubusercontent.com/46932830/203577638-ca31d62f-92b0-4757-b857-18e985133737.png)

previously it looked like this:
![imagen](https://user-images.githubusercontent.com/46932830/203577756-f98bc2bd-ec77-4aa8-98aa-3cec63513075.png)
