### PR TITLE
Fix the order when loading dashboards that were saved as opened

### DIFF
--- a/src/components/dashboard/dashboard_manager.gd
+++ b/src/components/dashboard/dashboard_manager.gd
@@ -176,7 +176,9 @@ func restore_default_dashboard() -> void:
 func open_user_dashboards():
 	inform_dashboard_selected = false
 	var dashboard_status = get_user_dashboards()
-	for dashboard in dashboard_status.open_dashboards:
+	var open_dashboards : Array = dashboard_status.open_dashboards
+	open_dashboards.invert()
+	for dashboard in open_dashboards:
 		if not available_dashboards.keys().has(dashboard):
 			continue
 		if dashboard_status.has("active_dashboard") and dashboard == dashboard_status.active_dashboard:


### PR DESCRIPTION
The problem is that when loading the dashboards for the first time, it will load them always at position 0 (position of the current tab), so it inverts the order each time.

Inverting the order of the array at loading solves this.