### PR TITLE
Remove spaces from instant tsdb query

### DIFF
--- a/src/components/dashboard/data_sources/data_source_time_series.gd
+++ b/src/components/dashboard/data_sources/data_source_time_series.gd
@@ -42,7 +42,7 @@ func make_query(dashboard_filters : Dictionary, attr : Dictionary) -> void:
 	if widget.data_type == BaseWidget.DATA_TYPE.INSTANT:
 		making_query = true
 		q += "&time=%d" % attr["to"]
-		set_request(API.query_tsdb(q.http_escape(), self))
+		set_request(API.query_tsdb(q.replace(" ",""), self))
 	else:
 		var from = attr["from"]
 		var to = attr["to"]


### PR DESCRIPTION
For some reason escaping the whole query doesn't work. It only works if we escape/remove the spaces though, so that's what this PR does.