### PR TITLE
Fixes to Resh Lite Popup

### DIFF
--- a/src/Main.tscn
+++ b/src/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=78 format=2]
+[gd_scene load_steps=71 format=2]
 
 [ext_resource path="res://components/popups/connect_popup.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/theme/dark_theme.tres" type="Theme" id=2]
@@ -48,14 +48,9 @@
 [ext_resource path="res://assets/generic/spin_shader.tres" type="Shader" id=46]
 [ext_resource path="res://assets/icons/icon_128_circle_thick.svg" type="Texture" id=47]
 [ext_resource path="res://scripts/ui_terminal_popup.gd" type="Script" id=48]
-[ext_resource path="res://components/elements/styled/styled_icon_button_hover.gd" type="Script" id=49]
 [ext_resource path="res://assets/icons/icon_128_terminal.svg" type="Texture" id=50]
-[ext_resource path="res://assets/icons/icon_128_fullscreen_variant.svg" type="Texture" id=51]
-[ext_resource path="res://assets/icons/icon_128_corner_grab_rounded.svg" type="Texture" id=52]
-[ext_resource path="res://assets/icons/icon_128_close_thick.svg" type="Texture" id=53]
-[ext_resource path="res://components/elements/drag_and_drop_control.gd" type="Script" id=54]
-[ext_resource path="res://components/elements/styled/custom_dragable_window_panel_container.gd" type="Script" id=55]
 [ext_resource path="res://assets/generic/screenspace_blur.tres" type="Shader" id=56]
+[ext_resource path="res://components/elements/styled/custom_dragable_window_panel.tscn" type="PackedScene" id=57]
 
 [sub_resource type="Gradient" id=20]
 colors = PoolColorArray( 0.243137, 0.141176, 0.372549, 1, 0.106957, 0.112697, 0.253906, 1 )
@@ -132,36 +127,26 @@ shader_param/turn_speed = -6.0
 shader_param/grad_length = 1.0
 shader_param/gradient_texture = SubResource( 32 )
 
-[sub_resource type="StyleBoxFlat" id=37]
-bg_color = Color( 1, 1, 1, 0.305882 )
+[sub_resource type="StyleBoxFlat" id=35]
+bg_color = Color( 1, 1, 1, 0.498039 )
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
-shadow_color = Color( 0, 0, 0, 0.145098 )
+shadow_color = Color( 0, 0, 0, 0.117647 )
 shadow_size = 20
 shadow_offset = Vector2( 0, 5 )
 
-[sub_resource type="ShaderMaterial" id=35]
+[sub_resource type="ShaderMaterial" id=36]
 shader = ExtResource( 56 )
 shader_param/lod = 3.0
 
-[sub_resource type="StyleBoxFlat" id=36]
-bg_color = Color( 0, 0, 0, 1 )
+[sub_resource type="StyleBoxFlat" id=37]
+bg_color = Color( 0.243137, 0.141176, 0.372549, 1 )
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
-
-[sub_resource type="StyleBoxFlat" id=2]
-content_margin_top = 4.0
-content_margin_bottom = 4.0
-bg_color = Color( 1, 1, 1, 1 )
-corner_radius_top_left = 4
-corner_radius_top_right = 4
-
-[sub_resource type="DynamicFont" id=4]
-size = 1
 
 [node name="Main" type="Control"]
 anchor_right = 1.0
@@ -761,138 +746,30 @@ stretch_mode = 6
 layer = 32
 script = ExtResource( 48 )
 
-[node name="TerminalPopup" type="PanelContainer" parent="TerminalPopup"]
-self_modulate = Color( 0.0901961, 0.113725, 0.129412, 1 )
-margin_right = 703.0
-margin_bottom = 433.0
-mouse_filter = 2
-custom_styles/panel = SubResource( 37 )
-script = ExtResource( 55 )
-
-[node name="BlurEffect" type="Panel" parent="TerminalPopup/TerminalPopup"]
-show_behind_parent = true
-material = SubResource( 35 )
-margin_right = 703.0
-margin_bottom = 433.0
-mouse_filter = 2
-custom_styles/panel = SubResource( 36 )
-
-[node name="Content" type="VBoxContainer" parent="TerminalPopup/TerminalPopup"]
-margin_right = 703.0
-margin_bottom = 433.0
-mouse_filter = 2
-
-[node name="Titlebar" type="PanelContainer" parent="TerminalPopup/TerminalPopup/Content"]
-self_modulate = Color( 0.0588235, 0.2, 0.337255, 1 )
-margin_right = 703.0
-margin_bottom = 28.0
-mouse_filter = 1
-custom_styles/panel = SubResource( 2 )
-script = ExtResource( 54 )
-
-[node name="Label" type="Label" parent="TerminalPopup/TerminalPopup/Content/Titlebar"]
-margin_top = 4.0
-margin_right = 703.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-text = "Window title"
-align = 1
-
-[node name="TitleButtons" type="HBoxContainer" parent="TerminalPopup/TerminalPopup/Content/Titlebar/Label"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -64.0
-margin_top = -12.5
-margin_bottom = 12.5
-rect_min_size = Vector2( 0, 22 )
-
-[node name="MaximizeButton" parent="TerminalPopup/TerminalPopup/Content/Titlebar/Label/TitleButtons" instance=ExtResource( 30 )]
-margin_right = 28.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 28, 22 )
-toggle_mode = true
-icon_tex = ExtResource( 51 )
-icon_margin = 2
-
-[node name="CloseButton" parent="TerminalPopup/TerminalPopup/Content/Titlebar/Label/TitleButtons" instance=ExtResource( 30 )]
-margin_left = 32.0
-margin_right = 60.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 28, 22 )
-icon_tex = ExtResource( 53 )
-icon_margin = 2
-
-[node name="Spacer" type="Control" parent="TerminalPopup/TerminalPopup/Content/Titlebar/Label/TitleButtons"]
-margin_left = 64.0
-margin_right = 64.0
-margin_bottom = 25.0
-
-[node name="Content" type="MarginContainer" parent="TerminalPopup/TerminalPopup/Content"]
-margin_top = 32.0
-margin_right = 703.0
-margin_bottom = 433.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_constants/margin_right = 10
-custom_constants/margin_top = 10
-custom_constants/margin_left = 10
-custom_constants/margin_bottom = 10
-
-[node name="TerminalManager" parent="TerminalPopup/TerminalPopup/Content/Content" instance=ExtResource( 9 )]
-margin_top = 10.0
-margin_right = 693.0
-margin_bottom = 391.0
-
-[node name="Footer" type="MarginContainer" parent="TerminalPopup/TerminalPopup/Content"]
+[node name="TerminalPanel" parent="TerminalPopup" instance=ExtResource( 57 )]
 visible = false
-margin_top = 610.0
+margin_left = 130.0
+margin_top = 50.0
+margin_right = 1030.0
+margin_bottom = 670.0
+custom_styles/panel = SubResource( 35 )
+window_content = ExtResource( 9 )
+default_size = Vector2( 900, 620 )
+window_title = "Resh Lite"
+show_footer = false
+content_margin_left_right = Vector2( 0, 0 )
+content_margin_top_bottom = Vector2( 0, 0 )
+
+[node name="BlurEffect" type="Panel" parent="TerminalPopup/TerminalPanel"]
+show_behind_parent = true
+material = SubResource( 36 )
 margin_right = 1193.0
 margin_bottom = 656.0
-custom_constants/margin_right = 10
-custom_constants/margin_left = 10
-custom_constants/margin_bottom = 14
-
-[node name="Footerbar" type="HBoxContainer" parent="TerminalPopup/TerminalPopup/Content/Footer"]
-margin_left = 10.0
-margin_right = 1183.0
-margin_bottom = 32.0
-alignment = 2
-
-[node name="AddWidgetButton" type="Button" parent="TerminalPopup/TerminalPopup/Content/Footer/Footerbar"]
-margin_left = 1097.0
-margin_right = 1173.0
-margin_bottom = 32.0
-text = "Accept"
-
-[node name="ResizeButtonContainer" type="Control" parent="TerminalPopup/TerminalPopup"]
-margin_right = 703.0
-margin_bottom = 433.0
 mouse_filter = 2
-
-[node name="ResizeButton" type="Button" parent="TerminalPopup/TerminalPopup/ResizeButtonContainer"]
-modulate = Color( 0.537255, 0.819608, 0.945098, 1 )
-self_modulate = Color( 1, 1, 1, 0.439216 )
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -16.0
-margin_top = -16.0
-rect_min_size = Vector2( 16, 16 )
-focus_mode = 0
-mouse_default_cursor_shape = 12
-size_flags_horizontal = 8
-size_flags_vertical = 8
-theme_type_variation = "ButtonBorderless"
-custom_fonts/font = SubResource( 4 )
-shortcut_in_tooltip = false
-enabled_focus_mode = 0
-icon = ExtResource( 52 )
-flat = true
-expand_icon = true
-script = ExtResource( 49 )
+input_pass_on_modal_close_click = false
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_styles/panel = SubResource( 37 )
 
 [node name="VisibilityTween" type="Tween" parent="TerminalPopup"]
 
@@ -946,11 +823,9 @@ script = ExtResource( 22 )
 [connection signal="pressed" from="MenuBar/MenuContainer/TopMenu/Title/HistoryButtons/HistoryFwdButton" to="MenuBar" method="_on_HistoryFwdButton_pressed"]
 [connection signal="pressed" from="MenuBar/MenuContainer/TopMenu/Title/ReshLiteBtn" to="MenuBar" method="_on_ReshLiteBtn_pressed"]
 [connection signal="gui_input" from="MenuBar/MenuContainer/TopMenu/Title/MainResotoLogo" to="MenuBar" method="_on_ResotoLogo_gui_input"]
+[connection signal="about_to_show" from="Popups/ConfirmPopup" to="Popups/ConfirmPopup" method="_on_ConfirmPopup_about_to_show"]
 [connection signal="pressed" from="Popups/WizardButton" to="Popups/WizardButton" method="_on_WizardButton_pressed"]
-[connection signal="close_popup" from="TerminalPopup/TerminalPopup" to="TerminalPopup" method="_on_TerminalPopup_close_popup"]
-[connection signal="pressed" from="TerminalPopup/TerminalPopup/Content/Titlebar/Label/TitleButtons/MaximizeButton" to="TerminalPopup/TerminalPopup" method="_on_MaximizeButton_pressed"]
-[connection signal="pressed" from="TerminalPopup/TerminalPopup/Content/Titlebar/Label/TitleButtons/CloseButton" to="TerminalPopup/TerminalPopup" method="_on_IconButton_pressed"]
-[connection signal="button_down" from="TerminalPopup/TerminalPopup/ResizeButtonContainer/ResizeButton" to="TerminalPopup/TerminalPopup" method="_on_ResizeButton_button_down"]
+[connection signal="popup_hide" from="TerminalPopup/TerminalPanel" to="TerminalPopup" method="hide_terminal_popup"]
 [connection signal="tween_all_completed" from="TerminalPopup/VisibilityTween" to="TerminalPopup" method="_on_VisibilityTween_tween_all_completed"]
 
 [editable path="MenuBar/MenuContainer/TopMenu/Title/ReshLiteBtn"]

--- a/src/assets/theme/dark_theme.tres
+++ b/src/assets/theme/dark_theme.tres
@@ -488,7 +488,7 @@ use_filter = true
 font_data = ExtResource( 15 )
 
 [sub_resource type="DynamicFont" id=42]
-size = 13
+size = 12
 use_mipmaps = true
 use_filter = true
 font_data = ExtResource( 12 )

--- a/src/components/dashboard/dashboard_container.gd
+++ b/src/components/dashboard/dashboard_container.gd
@@ -55,12 +55,12 @@ func _ready() -> void:
 	Style.add($VBoxContainer/MinimizedBar/MinimizeButton, Style.c.LIGHT)
 	Style.add(find_node("RefreshIcon"), Style.c.LIGHT)
 	
-	dashboard.dashboard_container = self
 	add_widget_popup.dashboard_container = self
-	
 	add_widget_popup.from_date = $DateRangeSelector.from.unix_time
 	add_widget_popup.to_date = $DateRangeSelector.to.unix_time
 	add_widget_popup.interval = 144
+	
+	dashboard.dashboard_container = self
 	dashboard.ts_start = $DateRangeSelector.from.unix_time
 	dashboard.ts_end = $DateRangeSelector.to.unix_time
 	dashboard.step = 144
@@ -72,9 +72,6 @@ func _ready() -> void:
 	InfrastructureInformation.connect("infra_info_updated", self, "_on_infra_info_updated")
 	
 	dashboard.lock(true)
-	
-	add_widget_popup.connect("about_to_show", self, "show_popup_bg")
-	add_widget_popup.connect("popup_hide", self, "hide_popup_bg")
 
 
 func _process(_delta):

--- a/src/components/dashboard/dashboard_container.tscn
+++ b/src/components/dashboard/dashboard_container.tscn
@@ -1,12 +1,12 @@
 [gd_scene load_steps=26 format=2]
 
-[ext_resource path="res://components/dashboard/new_widget_popup/new_widget_popup.tscn" type="PackedScene" id=1]
 [ext_resource path="res://components/shared/date_range_selector.tscn" type="PackedScene" id=2]
 [ext_resource path="res://components/elements/styled/icon_button_text.tscn" type="PackedScene" id=3]
 [ext_resource path="res://components/dashboard/dashboard_scroll_container.gd" type="Script" id=4]
 [ext_resource path="res://assets/icons/icon_128_delete_trashcan.svg" type="Texture" id=5]
 [ext_resource path="res://assets/icons/icon_128_rename.svg" type="Texture" id=6]
 [ext_resource path="res://components/dashboard/dashboard.gd" type="Script" id=7]
+[ext_resource path="res://components/dashboard/new_widget_popup/new_widget_popup.tscn" type="PackedScene" id=8]
 [ext_resource path="res://assets/icons/icon_128_fullscreen_variant.svg" type="Texture" id=9]
 [ext_resource path="res://assets/icons/icon_128_edit_frame.svg" type="Texture" id=10]
 [ext_resource path="res://assets/icons/icon_128_download_plain.svg" type="Texture" id=11]
@@ -308,9 +308,11 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0, 0.0509804, 0.0980392, 0.705882 )
 
-[node name="NewWidgetPopup" parent="." instance=ExtResource( 1 )]
-self_modulate = Color( 0.091, 0.11245, 0.13, 1 )
-default_size = Vector2( 800, 600 )
+[node name="NewWidgetPopup" parent="." instance=ExtResource( 8 )]
+visible = false
+margin_right = 1000.0
+margin_bottom = 700.0
+default_size = Vector2( 1000, 700 )
 
 [node name="DateRangeSelector" parent="." instance=ExtResource( 2 )]
 visible = false
@@ -428,6 +430,8 @@ autostart = true
 [connection signal="widget_scrolling" from="VBoxContainer/ScrollContainer/Content/Dashboard" to="VBoxContainer/ScrollContainer" method="_on_Dashboard_widget_scrolling"]
 [connection signal="timeout" from="VBoxContainer/ScrollContainer/Content/Dashboard/ResizeTimer" to="VBoxContainer/ScrollContainer/Content/Dashboard" method="_on_ResizeTimer_timeout"]
 [connection signal="timeout" from="VBoxContainer/ScrollContainer/ScrollTimer" to="." method="_on_ScrollTimer_timeout"]
+[connection signal="about_to_show" from="NewWidgetPopup" to="." method="show_popup_bg"]
+[connection signal="popup_hide" from="NewWidgetPopup" to="." method="hide_popup_bg"]
 [connection signal="widget_added" from="NewWidgetPopup" to="." method="_on_NewWidgetPopup_widget_added"]
 [connection signal="widget_added" from="NewWidgetPopup" to="VBoxContainer/ScrollContainer/Content/Dashboard" method="add_widget"]
 [connection signal="widget_edited" from="NewWidgetPopup" to="." method="_on_NewWidgetPopup_widget_edited"]

--- a/src/components/dashboard/data_sources/data_source_two_entry_aggregate.gd
+++ b/src/components/dashboard/data_sources/data_source_two_entry_aggregate.gd
@@ -56,5 +56,4 @@ func get_data() -> Dictionary:
 	}
 	
 	data.merge(.get_data())
-	print(JSON.print(data,"\t"))
 	return data

--- a/src/components/dashboard/new_widget_popup/new_widget_popup.gd
+++ b/src/components/dashboard/new_widget_popup/new_widget_popup.gd
@@ -1,4 +1,4 @@
-extends CustomPopupWindow
+extends CustomPopupWindowContainer
 
 signal widget_added(widget_data)
 signal widget_edited
@@ -61,7 +61,7 @@ func set_dashboard_container(_dc:DashboardContainer) -> void:
 		widget_type_options.add_item(key)
 
 
-func _on_AddWidgetButton_pressed() -> void:
+func _on_AcceptButton_pressed() -> void:
 	var widget
 	
 	if widget_to_edit == null or duplicating:
@@ -104,7 +104,7 @@ func _on_AddWidgetButton_pressed() -> void:
 		widget_to_edit = null
 		emit_signal("widget_edited")
 	
-	hide()
+	_hide_popup()
 	
 	var event : int 
 	if duplicating:
@@ -225,7 +225,6 @@ func get_control_for_property(property : Dictionary) -> Control:
 			control_signal = "value_changed"
 		TYPE_BOOL:
 			control = CheckBoxStyled.instance()
-			#control.size_flags_horizontal = 0
 			control.pressed = preview_widget[property.name]
 			control_signal = "toggled"
 		TYPE_STRING:
@@ -240,7 +239,7 @@ func get_control_for_property(property : Dictionary) -> Control:
 	
 	control.connect(control_signal, preview_widget, "set_"+property.name)
 	control.size_flags_horizontal |= SIZE_EXPAND
-			
+	
 	return control
 
 
@@ -441,7 +440,6 @@ func _close_popup():
 func _on_NewWidgetPopup_popup_hide():
 	duplicating = false
 	widget_to_edit = null
-	hide()
 	if preview_widget != null and is_instance_valid(preview_widget):
 		preview_widget.queue_free()
 	clear_data_sources()

--- a/src/components/dashboard/new_widget_popup/new_widget_popup.tscn
+++ b/src/components/dashboard/new_widget_popup/new_widget_popup.tscn
@@ -1,13 +1,13 @@
 [gd_scene load_steps=11 format=2]
 
-[ext_resource path="res://components/elements/styled/custom_dragable_window_popup.tscn" type="PackedScene" id=1]
-[ext_resource path="res://assets/icons/icon_128_add.svg" type="Texture" id=2]
-[ext_resource path="res://components/elements/styled/style_color_auto_remap.gd" type="Script" id=3]
-[ext_resource path="res://components/dashboard/new_widget_popup/new_widget_popup.gd" type="Script" id=4]
-[ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=5]
-[ext_resource path="res://assets/icons/icon_128_expand.svg" type="Texture" id=6]
-[ext_resource path="res://assets/icons/icon_128_collapse.svg" type="Texture" id=7]
-[ext_resource path="res://assets/icons/icon_128_attention_round.svg" type="Texture" id=8]
+[ext_resource path="res://components/elements/styled/custom_dragable_window_panel.tscn" type="PackedScene" id=1]
+[ext_resource path="res://assets/icons/icon_128_collapse.svg" type="Texture" id=2]
+[ext_resource path="res://assets/icons/icon_128_expand.svg" type="Texture" id=3]
+[ext_resource path="res://assets/icons/icon_128_add.svg" type="Texture" id=4]
+[ext_resource path="res://components/elements/styled/style_color_auto_remap.gd" type="Script" id=5]
+[ext_resource path="res://assets/icons/icon_128_attention_round.svg" type="Texture" id=6]
+[ext_resource path="res://components/dashboard/new_widget_popup/new_widget_popup.gd" type="Script" id=7]
+[ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=8]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -33,63 +33,50 @@ shadow_size = 10
 shadow_offset = Vector2( 0, 4 )
 
 [node name="NewWidgetPopup" instance=ExtResource( 1 )]
-visible = true
-margin_right = 800.0
-margin_bottom = 600.0
-script = ExtResource( 4 )
-
-[node name="Titlebar" parent="Content" index="0"]
-margin_right = 800.0
-margin_bottom = 28.0
-
-[node name="Label" parent="Content/Titlebar" index="0"]
-margin_right = 800.0
-margin_bottom = 24.0
-
-[node name="Content" parent="Content" index="1"]
-margin_top = 32.0
-margin_right = 800.0
-margin_bottom = 550.0
+script = ExtResource( 7 )
+default_size = Vector2( 800, 600 )
+window_title = "Add Widget"
+content_margin_top_bottom = Vector2( 4, 10 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Content/Content" index="0"]
 margin_left = 10.0
 margin_top = 10.0
-margin_right = 790.0
-margin_bottom = 508.0
+margin_right = 1183.0
+margin_bottom = 564.0
 custom_constants/separation = 10
 
 [node name="WidgetOptions" type="MarginContainer" parent="Content/Content/HBoxContainer" index="0"]
-margin_right = 385.0
-margin_bottom = 498.0
+margin_right = 581.0
+margin_bottom = 554.0
 size_flags_horizontal = 3
 __meta__ = {
 "_edit_use_anchors_": true
 }
 
 [node name="VBox" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions" index="0"]
-margin_right = 385.0
-margin_bottom = 498.0
+margin_right = 581.0
+margin_bottom = 554.0
 custom_constants/separation = 20
 
 [node name="WidgetBaseData" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox" index="0"]
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 113.0
 custom_constants/separation = 7
 
 [node name="WidgetNameVBox" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/WidgetBaseData" index="0"]
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 53.0
 custom_constants/separation = 1
 
 [node name="WidgetNameLabel" type="Label" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/WidgetBaseData/WidgetNameVBox" index="0"]
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 20.0
 theme_type_variation = "LabelBold"
 text = "Widget Name"
 
 [node name="WidgetNameEdit" type="LineEdit" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/WidgetBaseData/WidgetNameVBox" index="1"]
 margin_top = 21.0
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 53.0
 caret_blink = true
 caret_blink_speed = 0.5
@@ -97,19 +84,19 @@ caret_blink_speed = 0.5
 [node name="WidgetTypeVBox" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/WidgetBaseData" index="1"]
 unique_name_in_owner = true
 margin_top = 60.0
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 113.0
 custom_constants/separation = 1
 
 [node name="WidgetTypeLabel" type="Label" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/WidgetBaseData/WidgetTypeVBox" index="0"]
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 20.0
 theme_type_variation = "LabelBold"
 text = "Widget Type"
 
 [node name="WidgetType" type="OptionButton" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/WidgetBaseData/WidgetTypeVBox" index="1"]
 margin_top = 21.0
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 53.0
 
 [node name="HSeparator" type="HSeparator" parent="Content/Content/HBoxContainer/WidgetOptions/VBox" index="1"]
@@ -122,11 +109,11 @@ margin_bottom = 124.0
 [node name="AppliedFilterBox" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox" index="2"]
 unique_name_in_owner = true
 margin_top = 133.0
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 154.0
 
 [node name="DashboardFilterTitle" type="HBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/AppliedFilterBox" index="0"]
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 21.0
 
 [node name="ExpandGlobalFiltersButton" type="TextureButton" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/AppliedFilterBox/DashboardFilterTitle" index="0"]
@@ -136,8 +123,8 @@ margin_right = 14.0
 margin_bottom = 21.0
 rect_min_size = Vector2( 14, 21 )
 toggle_mode = true
-texture_normal = ExtResource( 7 )
-texture_pressed = ExtResource( 6 )
+texture_normal = ExtResource( 2 )
+texture_pressed = ExtResource( 3 )
 expand = true
 stretch_mode = 5
 
@@ -151,13 +138,13 @@ rect_min_size = Vector2( 20, 18 )
 mouse_filter = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
-texture = ExtResource( 8 )
+texture = ExtResource( 6 )
 expand = true
 stretch_mode = 6
 
 [node name="TitleLabel" type="Label" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/AppliedFilterBox/DashboardFilterTitle" index="2"]
 margin_left = 42.0
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 theme_type_variation = "LabelBold"
@@ -228,12 +215,12 @@ clip_text = true
 [node name="NewDataSourceHBox" type="HBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox" index="3"]
 unique_name_in_owner = true
 margin_top = 174.0
-margin_right = 385.0
+margin_right = 581.0
 margin_bottom = 207.0
 
 [node name="Label" type="Label" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/NewDataSourceHBox" index="0"]
 margin_top = 6.0
-margin_right = 224.0
+margin_right = 420.0
 margin_bottom = 26.0
 size_flags_horizontal = 3
 theme_type_variation = "LabelBold"
@@ -241,22 +228,22 @@ text = "Data Sources"
 
 [node name="DataSourceTypeOptionButton" type="OptionButton" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/NewDataSourceHBox" index="1"]
 unique_name_in_owner = true
-margin_left = 228.0
-margin_right = 348.667
+margin_left = 424.0
+margin_right = 544.667
 margin_bottom = 33.0
 disabled = true
 text = "Time Series"
 items = [ "Time Series", null, false, 0, null, "Aggregate Search", null, false, 1, null, "Resoto Search", null, false, 2, null ]
 selected = 0
 
-[node name="AddDataSourceButton" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/NewDataSourceHBox" index="2" instance=ExtResource( 5 )]
+[node name="AddDataSourceButton" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/NewDataSourceHBox" index="2" instance=ExtResource( 8 )]
 unique_name_in_owner = true
-margin_left = 352.0
-margin_right = 385.0
+margin_left = 548.0
+margin_right = 581.0
 hint_tooltip = "Add Data Source"
 size_flags_horizontal = 8
 size_flags_vertical = 1
-icon_tex = ExtResource( 2 )
+icon_tex = ExtResource( 4 )
 icon_margin = 6
 
 [node name="TemplatesAvailableLabel" type="Label" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/NewDataSourceHBox/AddDataSourceButton" index="1"]
@@ -271,61 +258,61 @@ text = "..."
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox" index="4"]
 margin_top = 227.0
-margin_right = 385.0
-margin_bottom = 498.0
+margin_right = 581.0
+margin_bottom = 554.0
 size_flags_vertical = 3
 scroll_horizontal_enabled = false
 
 [node name="DataSources" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetOptions/VBox/ScrollContainer" index="0"]
-margin_right = 385.0
+margin_right = 581.0
 size_flags_horizontal = 3
 
 [node name="WidgetPreview" type="MarginContainer" parent="Content/Content/HBoxContainer" index="1"]
-margin_left = 395.0
-margin_right = 780.0
-margin_bottom = 498.0
+margin_left = 591.0
+margin_right = 1173.0
+margin_bottom = 554.0
 size_flags_horizontal = 3
 __meta__ = {
 "_edit_use_anchors_": true
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetPreview" index="0"]
-margin_right = 385.0
-margin_bottom = 498.0
+margin_right = 582.0
+margin_bottom = 554.0
 custom_constants/separation = 5
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer" index="0"]
-margin_right = 385.0
-margin_bottom = 464.0
+margin_right = 582.0
+margin_bottom = 520.0
 size_flags_vertical = 3
 custom_constants/separation = 1
 
 [node name="WidgetPreviewLabel" type="Label" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer/VBoxContainer" index="0"]
-margin_right = 385.0
+margin_right = 582.0
 margin_bottom = 20.0
 theme_type_variation = "LabelBold"
 text = "Widget Preview"
 
 [node name="PreviewContainer" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer/VBoxContainer" index="1"]
 margin_top = 21.0
-margin_right = 385.0
-margin_bottom = 464.0
+margin_right = 582.0
+margin_bottom = 520.0
 size_flags_vertical = 3
 custom_constants/separation = 0
 
 [node name="PanelContainer" type="PanelContainer" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer/VBoxContainer/PreviewContainer" index="0"]
 self_modulate = Color( 0.0392157, 0.145098, 0.247059, 1 )
-margin_right = 385.0
+margin_right = 582.0
 margin_bottom = 30.0
 mouse_filter = 1
 custom_styles/panel = SubResource( 1 )
-script = ExtResource( 3 )
+script = ExtResource( 5 )
 
 [node name="WidgetPreviewTitleLabel" type="Label" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer/VBoxContainer/PreviewContainer/PanelContainer" index="0"]
 unique_name_in_owner = true
 margin_left = 5.0
 margin_top = 5.0
-margin_right = 380.0
+margin_right = 577.0
 margin_bottom = 25.0
 size_flags_horizontal = 3
 align = 1
@@ -339,20 +326,20 @@ margin_bottom = 461.0
 
 [node name="WidgetOptionsLabel" type="Label" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer" index="2"]
 unique_name_in_owner = true
-margin_top = 469.0
-margin_right = 385.0
-margin_bottom = 489.0
+margin_top = 525.0
+margin_right = 582.0
+margin_bottom = 545.0
 theme_type_variation = "LabelBold"
 text = "Widget Options"
 
 [node name="WidgetOptionsPanelContainer" type="VBoxContainer" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer" index="3"]
 unique_name_in_owner = true
-margin_top = 494.0
-margin_right = 385.0
-margin_bottom = 498.0
+margin_top = 550.0
+margin_right = 582.0
+margin_bottom = 554.0
 
 [node name="Options" type="GridContainer" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer/WidgetOptionsPanelContainer" index="0"]
-margin_right = 385.0
+margin_right = 582.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 30
 columns = 2
@@ -360,22 +347,8 @@ columns = 2
 [node name="ColorControllersContainer" type="HBoxContainer" parent="Content/Content/HBoxContainer/WidgetPreview/VBoxContainer/WidgetOptionsPanelContainer" index="1"]
 unique_name_in_owner = true
 margin_top = 4.0
-margin_right = 385.0
+margin_right = 582.0
 margin_bottom = 4.0
-
-[node name="Footer" parent="Content" index="2"]
-margin_top = 554.0
-margin_right = 800.0
-margin_bottom = 600.0
-
-[node name="Footerbar" parent="Content/Footer" index="0"]
-margin_right = 790.0
-margin_bottom = 32.0
-
-[node name="AddWidgetButton" parent="Content/Footer/Footerbar" index="0"]
-margin_left = 704.0
-margin_right = 780.0
-margin_bottom = 32.0
 
 [node name="TemplatePopup" type="PopupPanel" parent="." index="2"]
 self_modulate = Color( 0.0588235, 0.2, 0.337255, 1 )
@@ -384,7 +357,7 @@ anchor_right = 1.0
 margin_left = -800.0
 margin_bottom = 600.0
 custom_styles/panel = SubResource( 2 )
-script = ExtResource( 3 )
+script = ExtResource( 5 )
 
 [node name="VBox" type="VBoxContainer" parent="TemplatePopup" index="0"]
 margin_left = 4.0
@@ -428,4 +401,5 @@ margin_bottom = 57.0
 [connection signal="pressed" from="Content/Content/HBoxContainer/WidgetOptions/VBox/AppliedFilterBox/DashboardFilterTitle/ExpandGlobalFiltersButton" to="." method="_on_ExpandGlobalFiltersButton_pressed"]
 [connection signal="item_selected" from="Content/Content/HBoxContainer/WidgetOptions/VBox/NewDataSourceHBox/DataSourceTypeOptionButton" to="." method="_on_DataSourceTypeOptionButton_item_selected"]
 [connection signal="pressed" from="Content/Content/HBoxContainer/WidgetOptions/VBox/NewDataSourceHBox/AddDataSourceButton" to="." method="_on_AddDataSource_pressed"]
+[connection signal="pressed" from="Content/Footer/Footerbar/AcceptButton" to="." method="_on_AcceptButton_pressed"]
 [connection signal="pressed" from="TemplatePopup/VBox/AddEmptyButton" to="." method="_on_AddDataSource"]

--- a/src/components/elements/styled/custom_dragable_window_panel.gd
+++ b/src/components/elements/styled/custom_dragable_window_panel.gd
@@ -1,15 +1,21 @@
 extends PanelContainer
 class_name CustomPopupWindowContainer
 
-signal close_popup
+signal popup_hide
+signal about_to_show
 
 const TopMenuHeight:= 40
 
-export var default_size:= Vector2.ONE
+export (PackedScene) var window_content : PackedScene
+export var default_size:= Vector2(200, 200)
+export var window_title:= "Window Title" setget set_window_title
 export var show_close_icon:= true
 export var show_max_icon:= true
+export var show_footer:= true
 export var can_drag:= true
 export var can_resize:= true
+export var content_margin_left_right:= Vector2(10,10)
+export var content_margin_top_bottom:= Vector2(10,10)
 
 var is_dragging:= false
 var is_maximized:= false
@@ -26,29 +32,46 @@ onready var resize_btn = $ResizeButtonContainer/ResizeButton
 
 func _ready():
 	hide()
+	rect_size = default_size
+	size_before_max = default_size
+	$Content/Content.add_constant_override("margin_left", content_margin_left_right.x)
+	$Content/Content.add_constant_override("margin_right", content_margin_left_right.y)
+	$Content/Content.add_constant_override("margin_top", content_margin_top_bottom.x)
+	$Content/Content.add_constant_override("margin_bottom", content_margin_top_bottom.y)
 	$Content/Titlebar.target = self
 	connect("visibility_changed", self, "_on_change_visibility")
-	rect_size = default_size
 	_g.connect("ui_scale_changed", self, "on_ui_scale_changed")
+	set_window_title(window_title)
+	$Content/Footer.visible = show_footer
+	if window_content != null:
+		var new_content = window_content.instance()
+		$Content/Content.add_child(new_content)
+
+
+func popup_centered():
+	show()
+	var w_size = (OS.window_size / _g.ui_scale)
+	rect_global_position = (w_size/2 - rect_size/2) - Vector2(0, -TopMenuHeight)
 
 
 func on_ui_scale_changed() -> void:
 	if visible:
 		var w_size = (OS.window_size / _g.ui_scale)
-		var popup_size = rect_size
-		rect_position = (w_size/2 - popup_size/2) - Vector2(0, -TopMenuHeight)
+		rect_global_position = (w_size/2 - rect_size/2) - Vector2(0, -TopMenuHeight)
 		rect_size = Vector2(
-			clamp(rect_size.x, 1, w_size.x - rect_position.x),
-			clamp(rect_size.y, 1, w_size.y - rect_position.y)
+			clamp(rect_size.x, 1, w_size.x - rect_global_position.x),
+			clamp(rect_size.y, 1, w_size.y - rect_global_position.y)
 		)
 
 
 func set_window_title(_new_title:String):
+	window_title = _new_title
 	$Content/Titlebar/Label.text = _new_title
 
 
 func _on_change_visibility():
 	if visible:
+		emit_signal("about_to_show")
 		reset_settings()
 
 
@@ -69,7 +92,7 @@ func _process(_delta:float):
 	var w_size = OS.window_size / _g.ui_scale
 	if is_dragging:
 		var m_pos = get_global_mouse_position() - drag_start_position
-		rect_position = Vector2(
+		rect_global_position = Vector2(
 			clamp(m_pos.x, 0, w_size.x - rect_size.x),
 			clamp(m_pos.y, TopMenuHeight, w_size.y - rect_size.y)
 		)
@@ -77,9 +100,10 @@ func _process(_delta:float):
 	if is_resizing:
 		var n_size = orig_size + (get_global_mouse_position() - resize_click_origin)
 		rect_size = Vector2(
-			clamp(n_size.x, 1, w_size.x - rect_position.x),
-			clamp(n_size.y, 1, w_size.y - rect_position.y)
+			clamp(n_size.x, 1, w_size.x - rect_global_position.x),
+			clamp(n_size.y, 1, w_size.y - rect_global_position.y)
 		)
+		size_before_max = rect_size
 
 
 func start_drag(_drag_position:Vector2):
@@ -97,12 +121,9 @@ func start_drag(_drag_position:Vector2):
 	drag_start_position = _drag_position - maximized_offset
 
 
-func _on_IconButton_pressed():
-	_close_popup()
-
-
-func _close_popup():
-	emit_signal("close_popup")
+func _hide_popup():
+	hide()
+	emit_signal("popup_hide")
 
 
 func _on_ResizeButton_button_down():
@@ -129,3 +150,7 @@ func _on_MaximizeButton_pressed():
 	else:
 		rect_position = pos_before_max
 		rect_size = size_before_max
+
+
+func _on_CloseButton_pressed():
+	_hide_popup()

--- a/src/components/elements/styled/custom_dragable_window_panel.tscn
+++ b/src/components/elements/styled/custom_dragable_window_panel.tscn
@@ -1,0 +1,149 @@
+[gd_scene load_steps=11 format=2]
+
+[ext_resource path="res://components/elements/styled/styled_icon_button_hover.gd" type="Script" id=1]
+[ext_resource path="res://components/elements/styled/custom_dragable_window_panel.gd" type="Script" id=2]
+[ext_resource path="res://components/elements/drag_and_drop_control.gd" type="Script" id=3]
+[ext_resource path="res://assets/icons/icon_128_close_thick.svg" type="Texture" id=4]
+[ext_resource path="res://assets/icons/icon_128_fullscreen_variant.svg" type="Texture" id=5]
+[ext_resource path="res://assets/icons/icon_128_corner_grab_rounded.svg" type="Texture" id=6]
+[ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=7]
+
+[sub_resource type="StyleBoxFlat" id=3]
+bg_color = Color( 1, 1, 1, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+shadow_color = Color( 0, 0, 0, 0.117647 )
+shadow_size = 20
+shadow_offset = Vector2( 0, 5 )
+
+[sub_resource type="StyleBoxFlat" id=2]
+content_margin_top = 4.0
+content_margin_bottom = 4.0
+bg_color = Color( 1, 1, 1, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+
+[sub_resource type="DynamicFont" id=4]
+size = 1
+
+[node name="CustomDragableWindowPopup" type="PanelContainer"]
+self_modulate = Color( 0.0901961, 0.113725, 0.129412, 1 )
+margin_right = 1193.0
+margin_bottom = 656.0
+custom_styles/panel = SubResource( 3 )
+script = ExtResource( 2 )
+
+[node name="Content" type="VBoxContainer" parent="."]
+margin_right = 1193.0
+margin_bottom = 656.0
+
+[node name="Titlebar" type="PanelContainer" parent="Content"]
+self_modulate = Color( 0.0588235, 0.2, 0.337255, 1 )
+margin_right = 1193.0
+margin_bottom = 28.0
+custom_styles/panel = SubResource( 2 )
+script = ExtResource( 3 )
+
+[node name="Label" type="Label" parent="Content/Titlebar"]
+margin_top = 4.0
+margin_right = 1193.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+text = "Window title"
+align = 1
+
+[node name="TitleButtons" type="HBoxContainer" parent="Content/Titlebar/Label"]
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+margin_left = -64.0
+margin_top = -12.5
+margin_bottom = 12.5
+rect_min_size = Vector2( 0, 22 )
+
+[node name="MaximizeButton" parent="Content/Titlebar/Label/TitleButtons" instance=ExtResource( 7 )]
+margin_right = 28.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 28, 22 )
+toggle_mode = true
+icon_tex = ExtResource( 5 )
+icon_margin = 2
+
+[node name="CloseButton" parent="Content/Titlebar/Label/TitleButtons" instance=ExtResource( 7 )]
+margin_left = 32.0
+margin_right = 60.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 28, 22 )
+icon_tex = ExtResource( 4 )
+icon_margin = 2
+
+[node name="Spacer" type="Control" parent="Content/Titlebar/Label/TitleButtons"]
+margin_left = 64.0
+margin_right = 64.0
+margin_bottom = 25.0
+
+[node name="Content" type="MarginContainer" parent="Content"]
+margin_top = 32.0
+margin_right = 1193.0
+margin_bottom = 606.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/margin_right = 10
+custom_constants/margin_top = 10
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 10
+
+[node name="Footer" type="MarginContainer" parent="Content"]
+margin_top = 610.0
+margin_right = 1193.0
+margin_bottom = 656.0
+custom_constants/margin_right = 10
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 14
+
+[node name="Footerbar" type="HBoxContainer" parent="Content/Footer"]
+margin_left = 10.0
+margin_right = 1183.0
+margin_bottom = 32.0
+alignment = 2
+
+[node name="AcceptButton" type="Button" parent="Content/Footer/Footerbar"]
+margin_left = 1097.0
+margin_right = 1173.0
+margin_bottom = 32.0
+text = "Accept"
+
+[node name="ResizeButtonContainer" type="Control" parent="."]
+margin_right = 1193.0
+margin_bottom = 656.0
+mouse_filter = 2
+
+[node name="ResizeButton" type="Button" parent="ResizeButtonContainer"]
+modulate = Color( 0.537255, 0.819608, 0.945098, 1 )
+self_modulate = Color( 1, 1, 1, 0.439216 )
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -16.0
+margin_top = -16.0
+rect_min_size = Vector2( 16, 16 )
+focus_mode = 0
+mouse_default_cursor_shape = 12
+size_flags_horizontal = 8
+size_flags_vertical = 8
+theme_type_variation = "ButtonBorderless"
+custom_fonts/font = SubResource( 4 )
+shortcut_in_tooltip = false
+enabled_focus_mode = 0
+icon = ExtResource( 6 )
+flat = true
+expand_icon = true
+script = ExtResource( 1 )
+
+[connection signal="pressed" from="Content/Titlebar/Label/TitleButtons/MaximizeButton" to="." method="_on_MaximizeButton_pressed"]
+[connection signal="pressed" from="Content/Titlebar/Label/TitleButtons/CloseButton" to="." method="_on_CloseButton_pressed"]
+[connection signal="button_down" from="ResizeButtonContainer/ResizeButton" to="." method="_on_ResizeButton_button_down"]

--- a/src/components/popups/popup_connect.gd
+++ b/src/components/popups/popup_connect.gd
@@ -37,6 +37,7 @@ func _on_ConnectPopup_about_to_show() -> void:
 	$Content/Margin/Connect/Adress.show()
 	connect_button.show()
 	status.text = "Resoto Core connection settings."
+	_g.emit_signal("resh_lite_popup_hide")
 
 
 func connect_to_core() -> void:

--- a/src/components/popups/popup_generic_confirm.gd
+++ b/src/components/popups/popup_generic_confirm.gd
@@ -63,3 +63,7 @@ func send_response(_button_pressed:String):
 func _on_LineEdit_text_entered(_new_text):
 	send_response("left")
 	hide()
+
+
+func _on_ConfirmPopup_about_to_show():
+	_g.emit_signal("resh_lite_popup_hide")

--- a/src/components/popups/popup_ui_settings.gd
+++ b/src/components/popups/popup_ui_settings.gd
@@ -59,6 +59,7 @@ func _on_UISettings_about_to_show() -> void:
 		footerbar.move_child(accept_button, 1)
 	else:
 		footerbar.move_child(accept_button, 0)
+	_g.emit_signal("resh_lite_popup_hide")
 	is_dirty = false
 	$Content/Content/SettingsTabs.current_tab = 0
 	$"%ScaleLevelLabel".text = str(_g.ui_scale*100) + " %"

--- a/src/components/terminal/component_terminal.gd
+++ b/src/components/terminal/component_terminal.gd
@@ -69,7 +69,8 @@ func _input(event:InputEvent) -> void:
 	or !terminal_active
 	or _g.popup_manager.popup_active()
 	or not event is InputEventKey
-	or _g.focus_in_search):
+	or _g.focus_in_search
+	or not get_global_rect().has_point(get_global_mouse_position())):
 		return
 	
 	if not command.has_focus() and event.pressed and not MODIFIER_KEYS.has(event.scancode) and event.scancode != KEY_ESCAPE:

--- a/src/project.godot
+++ b/src/project.godot
@@ -87,7 +87,7 @@ _global_script_classes=[ {
 "base": "PanelContainer",
 "class": "CustomPopupWindowContainer",
 "language": "GDScript",
-"path": "res://components/elements/styled/custom_dragable_window_panel_container.gd"
+"path": "res://components/elements/styled/custom_dragable_window_panel.gd"
 }, {
 "base": "Control",
 "class": "DashboardContainer",

--- a/src/scripts/ui_terminal_popup.gd
+++ b/src/scripts/ui_terminal_popup.gd
@@ -5,13 +5,13 @@ const DEFAULT_POSITION := Vector2(130, 50)
 var terminal_popup_rect := Rect2(0,0,0,0)
 var hiding := false
 
-onready var terminal_popup := $TerminalPopup
+onready var terminal_popup := $TerminalPanel
 onready var tween = $VisibilityTween
 
 func _ready():
 	terminal_popup.modulate.a = 0.0
 	_g.connect("resh_lite_popup", self, "change_terminal_popup_visibility")
-	_g.connect("resh_lite_popup_hide", self, "hide_terminal_popup()")
+	_g.connect("resh_lite_popup_hide", self, "hide_terminal_popup")
 	terminal_popup.set_window_title("Resoto Shell Lite")
 
 
@@ -31,7 +31,6 @@ func show_terminal_popup():
 		tween.interpolate_property(terminal_popup, "rect_position", DEFAULT_POSITION+Vector2(0, 30), DEFAULT_POSITION, 0.4, Tween.TRANS_EXPO, Tween.EASE_OUT)
 		tween.interpolate_property(terminal_popup, "rect_scale", Vector2(1, 0.4), Vector2.ONE, 0.1, Tween.TRANS_EXPO, Tween.EASE_OUT)
 		tween.start()
-		terminal_popup.rect_size = Vector2(900, 620)
 	else:
 		terminal_popup.show()
 		terminal_popup.rect_pivot_offset = terminal_popup_rect.size/2
@@ -50,11 +49,6 @@ func hide_terminal_popup():
 	tween.interpolate_property(terminal_popup, "rect_scale", Vector2.ONE, Vector2(1, 0.4), 0.2, Tween.TRANS_EXPO, Tween.EASE_OUT)
 	tween.start()
 	hiding = true
-	
-
-
-func _on_TerminalPopup_close_popup():
-	hide_terminal_popup()
 
 
 func _on_VisibilityTween_tween_all_completed():


### PR DESCRIPTION
**In this PR**
- Fix for Resh Lite Popup stealing focus (will now only do this when the mouse is over the popup).
- Removed a debug print from the two entries aggregate data source.
- Certain Popups will hide Resh Lite to avoid conflicting input.
- Added a new Window Popup class based on PanelContainer instead of Popup. And changed the "Add/Edit Widget popup" to this new class.

**More detail about the last change:**
The Popup class steals all input as long as it is displayed in exclusive mode. This produced problems with Resh Lite.
As long as the "New Widget" Popup was visible, Resh Lite was not usable. This is a situation where I can imagine having a terminal is especially helpful, so I wanted it to work. The only solution was to move the popup from the Popup class to a "custom" one.

For the most part it worked right away, I had to introduce some fixes, but yeah. Looks like a bigger change in this PR, but isn't that bad 🙈