### PR TITLE
Improved zoom button group

### DIFF
--- a/src/Main.tscn
+++ b/src/Main.tscn
@@ -28,7 +28,7 @@
 [ext_resource path="res://components/node_list/node_list_element_component.gd" type="Script" id=26]
 [ext_resource path="res://assets/icons/icon_128_settings.svg" type="Texture" id=27]
 [ext_resource path="res://components/elements/history_button.tscn" type="PackedScene" id=28]
-[ext_resource path="res://assets/icons/icon_128_substract_minus_remove.svg" type="Texture" id=29]
+[ext_resource path="res://components/shared/zoom_group.tscn" type="PackedScene" id=29]
 [ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=30]
 [ext_resource path="res://components/popups/popup_ui_settings.tscn" type="PackedScene" id=31]
 [ext_resource path="res://components/wizard/setup_wizard_component.gd" type="Script" id=32]
@@ -429,31 +429,42 @@ icon_margin = -5
 [node name="Spacer" type="Control" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems"]
 margin_top = 199.0
 margin_right = 310.0
-margin_bottom = 943.0
+margin_bottom = 963.0
 size_flags_vertical = 3
 
 [node name="UISettings" type="HBoxContainer" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems"]
-margin_top = 947.0
+margin_top = 967.0
 margin_right = 310.0
-margin_bottom = 980.0
+margin_bottom = 1000.0
 alignment = 1
 
+[node name="UIZoomGroup" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings" instance=ExtResource( 29 )]
+margin_right = 96.0
+
+[node name="Spacer" type="Control" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings"]
+margin_left = 100.0
+margin_right = 199.0
+margin_bottom = 33.0
+size_flags_horizontal = 3
+
 [node name="ButtonUISettings" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings" instance=ExtResource( 30 )]
+margin_left = 203.0
+margin_right = 236.0
 hint_tooltip = "Settings"
 size_flags_horizontal = 0
 icon_tex = ExtResource( 27 )
 
 [node name="ButtonDocs" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings" instance=ExtResource( 30 )]
-margin_left = 37.0
-margin_right = 70.0
+margin_left = 240.0
+margin_right = 273.0
 hint_tooltip = "Documentation (external link)"
 icon_tex = ExtResource( 11 )
 
 [node name="ButtonMessageLog" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings" instance=ExtResource( 30 )]
-margin_left = 74.0
-margin_right = 107.0
+margin_left = 277.0
+margin_right = 310.0
 hint_tooltip = "Notifications"
-size_flags_horizontal = 2
+size_flags_horizontal = 0
 icon_tex = ExtResource( 36 )
 
 [node name="NotificationAnchor" type="Control" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings/ButtonMessageLog"]
@@ -467,29 +478,8 @@ mouse_filter = 2
 visible = false
 margin_right = 10.0
 
-[node name="ButtonUIScaleMinus" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings" instance=ExtResource( 30 )]
-margin_left = 215.0
-margin_right = 239.0
-rect_min_size = Vector2( 24, 20 )
-hint_tooltip = "Change UI Scale"
-icon_tex = ExtResource( 29 )
-
-[node name="ZoomScaleLabel" type="Label" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings"]
-unique_name_in_owner = true
-margin_left = 243.0
-margin_top = 6.0
-margin_right = 282.0
-margin_bottom = 26.0
-text = "100%"
-
-[node name="ButtonUIScalePlus" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings" instance=ExtResource( 30 )]
-margin_left = 286.0
-margin_right = 310.0
-rect_min_size = Vector2( 24, 20 )
-hint_tooltip = "Change UI Scale"
-icon_tex = ExtResource( 20 )
-
 [node name="ResotoUIVersion" type="Label" parent="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems"]
+visible = false
 modulate = Color( 1, 1, 1, 0.196078 )
 margin_top = 984.0
 margin_right = 310.0
@@ -814,8 +804,6 @@ script = ExtResource( 22 )
 [connection signal="pressed" from="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings/ButtonUISettings" to="MenuBar" method="_on_ButtonUISettings_pressed"]
 [connection signal="pressed" from="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings/ButtonDocs" to="MenuBar" method="_on_ButtonDocs_pressed"]
 [connection signal="pressed" from="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings/ButtonMessageLog" to="MenuBar" method="_on_ButtonMessageLog_pressed"]
-[connection signal="pressed" from="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings/ButtonUIScaleMinus" to="MenuBar" method="_on_ButtonUIScaleMinus_pressed"]
-[connection signal="pressed" from="MenuBar/HamburgerMenu/Panel/MenuContent/HamburgerMenuItems/UISettings/ButtonUIScalePlus" to="MenuBar" method="_on_ButtonUIScalePlus_pressed"]
 [connection signal="gui_input" from="MenuBar/HamburgerMenu/ShadowSide" to="MenuBar" method="_on_click_detection_gui_input"]
 [connection signal="gui_input" from="MenuBar/HamburgerMenu/ClickDetection" to="MenuBar" method="_on_click_detection_gui_input"]
 [connection signal="hamburger_button_pressed" from="MenuBar/MenuContainer/TopMenu/Title/HamburgerButton" to="MenuBar" method="_on_HamburgerButton_hamburger_button_pressed"]

--- a/src/components/shared/zoom_elements.gd
+++ b/src/components/shared/zoom_elements.gd
@@ -21,7 +21,7 @@ func _on_ButtonUIScalePlus_pressed():
 
 func on_ui_scale_changed():
 	zoom_label.text = str(_g.ui_scale*100) + "%"
-	zoom_spacer.rect_min_size.x = 40 / _g.ui_scale
+	zoom_spacer.rect_min_size.x = 45 / _g.ui_scale
 	zoom_scaler.scale = Vector2.ONE / _g.ui_scale
 	$ButtonUIScaleMinus.rect_min_size.x = 24 / _g.ui_scale
 	$ButtonUIScalePlus.rect_min_size.x = 24 / _g.ui_scale

--- a/src/components/shared/zoom_elements.gd
+++ b/src/components/shared/zoom_elements.gd
@@ -1,0 +1,27 @@
+extends HBoxContainer
+
+
+onready var zoom_label = $LabelSpacer/Control/Attach/ZoomScaleLabel
+onready var zoom_spacer = $LabelSpacer
+onready var zoom_scaler = $LabelSpacer/Control/Attach
+
+
+func _ready():
+	get_tree().root.connect("size_changed", self, "on_ui_scale_changed")
+	_g.connect("ui_scale_changed", self, "on_ui_scale_changed")
+
+
+func _on_ButtonUIScaleMinus_pressed():
+	_g.emit_signal("ui_scale_decrease")
+
+
+func _on_ButtonUIScalePlus_pressed():
+	_g.emit_signal("ui_scale_increase")
+
+
+func on_ui_scale_changed():
+	zoom_label.text = str(_g.ui_scale*100) + "%"
+	zoom_spacer.rect_min_size.x = 40 / _g.ui_scale
+	zoom_scaler.scale = Vector2.ONE / _g.ui_scale
+	$ButtonUIScaleMinus.rect_min_size.x = 24 / _g.ui_scale
+	$ButtonUIScalePlus.rect_min_size.x = 24 / _g.ui_scale

--- a/src/components/shared/zoom_group.tscn
+++ b/src/components/shared/zoom_group.tscn
@@ -6,8 +6,9 @@
 [ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=4]
 
 [node name="UIZoomGroup" type="HBoxContainer"]
-margin_right = 95.0
+margin_right = 88.0
 margin_bottom = 33.0
+custom_constants/separation = 0
 script = ExtResource( 3 )
 
 [node name="ButtonUIScaleMinus" parent="." instance=ExtResource( 4 )]
@@ -18,19 +19,18 @@ icon_tex = ExtResource( 2 )
 icon_margin = 2
 
 [node name="LabelSpacer" type="CenterContainer" parent="."]
-margin_left = 28.0
-margin_right = 68.0
+margin_left = 24.0
+margin_right = 69.0
 margin_bottom = 33.0
-rect_min_size = Vector2( 40, 0 )
+rect_min_size = Vector2( 45, 0 )
 
 [node name="Control" type="Control" parent="LabelSpacer"]
-margin_left = 20.0
+margin_left = 22.0
 margin_top = 16.0
-margin_right = 20.0
+margin_right = 22.0
 margin_bottom = 16.0
 
 [node name="Attach" type="Node2D" parent="LabelSpacer/Control"]
-z_index = 1
 
 [node name="ZoomScaleLabel" type="Label" parent="LabelSpacer/Control/Attach"]
 unique_name_in_owner = true
@@ -44,8 +44,8 @@ text = "100%"
 align = 1
 
 [node name="ButtonUIScalePlus" parent="." instance=ExtResource( 4 )]
-margin_left = 72.0
-margin_right = 96.0
+margin_left = 69.0
+margin_right = 93.0
 rect_min_size = Vector2( 24, 20 )
 hint_tooltip = "Change UI Scale"
 icon_tex = ExtResource( 1 )

--- a/src/components/shared/zoom_group.tscn
+++ b/src/components/shared/zoom_group.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://assets/icons/icon_128_add.svg" type="Texture" id=1]
+[ext_resource path="res://assets/icons/icon_128_substract_minus_remove.svg" type="Texture" id=2]
+[ext_resource path="res://components/shared/zoom_elements.gd" type="Script" id=3]
+[ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=4]
+
+[node name="UIZoomGroup" type="HBoxContainer"]
+margin_right = 95.0
+margin_bottom = 33.0
+script = ExtResource( 3 )
+
+[node name="ButtonUIScaleMinus" parent="." instance=ExtResource( 4 )]
+margin_right = 24.0
+rect_min_size = Vector2( 24, 20 )
+hint_tooltip = "Change UI Scale"
+icon_tex = ExtResource( 2 )
+icon_margin = 2
+
+[node name="LabelSpacer" type="CenterContainer" parent="."]
+margin_left = 28.0
+margin_right = 68.0
+margin_bottom = 33.0
+rect_min_size = Vector2( 40, 0 )
+
+[node name="Control" type="Control" parent="LabelSpacer"]
+margin_left = 20.0
+margin_top = 16.0
+margin_right = 20.0
+margin_bottom = 16.0
+
+[node name="Attach" type="Node2D" parent="LabelSpacer/Control"]
+z_index = 1
+
+[node name="ZoomScaleLabel" type="Label" parent="LabelSpacer/Control/Attach"]
+unique_name_in_owner = true
+margin_left = -20.0
+margin_top = -10.0
+margin_right = 20.0
+margin_bottom = 10.0
+rect_min_size = Vector2( 40, 20 )
+rect_pivot_offset = Vector2( 20, 10 )
+text = "100%"
+align = 1
+
+[node name="ButtonUIScalePlus" parent="." instance=ExtResource( 4 )]
+margin_left = 72.0
+margin_right = 96.0
+rect_min_size = Vector2( 24, 20 )
+hint_tooltip = "Change UI Scale"
+icon_tex = ExtResource( 1 )
+icon_margin = 2
+
+[connection signal="pressed" from="ButtonUIScaleMinus" to="." method="_on_ButtonUIScaleMinus_pressed"]
+[connection signal="pressed" from="ButtonUIScalePlus" to="." method="_on_ButtonUIScalePlus_pressed"]

--- a/src/components/wizard/wizard_component.tscn
+++ b/src/components/wizard/wizard_component.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://components/wizard/wizard_component.gd" type="Script" id=1]
 [ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=2]
@@ -10,6 +10,7 @@
 [ext_resource path="res://assets/icons/icon_128_discord.svg" type="Texture" id=8]
 [ext_resource path="res://components/wizard/wizard_character.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/icons/icon_128_sound_on.svg" type="Texture" id=10]
+[ext_resource path="res://components/shared/zoom_group.tscn" type="PackedScene" id=11]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 20.0
@@ -93,7 +94,7 @@ rect_min_size = Vector2( 0, 50 )
 custom_constants/separation = 10
 
 [node name="SectionTitleLabel" type="Label" parent="BG/StepDisplay/Titlebar"]
-margin_right = 1630.0
+margin_right = 1524.0
 margin_bottom = 36.0
 size_flags_horizontal = 3
 size_flags_vertical = 0
@@ -153,8 +154,8 @@ icon_tex = ExtResource( 10 )
 icon_margin = 3
 
 [node name="HelpDiscordButton" parent="BG/StepDisplay/Titlebar" instance=ExtResource( 2 )]
-margin_left = 1640.0
-margin_right = 1680.0
+margin_left = 1534.0
+margin_right = 1574.0
 margin_bottom = 40.0
 rect_min_size = Vector2( 40, 40 )
 hint_tooltip = "[center][img=200x60]res://assets/resoto/Resoto_logo_and_text.svg[/img]
@@ -169,6 +170,13 @@ theme_type_variation = "ButtonFlatDefault"
 script = ExtResource( 7 )
 icon_tex = ExtResource( 8 )
 icon_margin = 3
+
+[node name="UIZoomGroup" parent="BG/StepDisplay/Titlebar" instance=ExtResource( 11 )]
+margin_left = 1584.0
+margin_right = 1680.0
+margin_bottom = 40.0
+rect_min_size = Vector2( 0, 40 )
+size_flags_vertical = 0
 
 [node name="StepContent" type="Control" parent="BG/StepDisplay"]
 margin_top = 70.0

--- a/src/scripts/ui_menu.gd
+++ b/src/scripts/ui_menu.gd
@@ -86,7 +86,6 @@ func close_menu():
 
 func on_ui_scale_changed():
 	hb_menu.rect_size.y = OS.window_size.y / _g.ui_scale
-	$"%ZoomScaleLabel".text = str(_g.ui_scale*100) + "%"
 
 
 func _on_HamburgerButton_hamburger_button_pressed(pressed:bool):
@@ -140,14 +139,6 @@ func _on_navigation_index_changed(id : int):
 func _on_ButtonUISettings_pressed():
 	_g.popup_manager.open_popup("UISettingsPopup")
 	close_menu()
-
-
-func _on_ButtonUIScaleMinus_pressed():
-	_g.emit_signal("ui_scale_decrease")
-
-
-func _on_ButtonUIScalePlus_pressed():
-	_g.emit_signal("ui_scale_increase")
 
 
 func _on_ReshLiteBtn_pressed():


### PR DESCRIPTION
The zoom button group now is a reusable scene. It will try to stay in the same size indipendent of the ui scale.
As it is hard to make it using a fixed position using Godot UI system, this is the next best thing.

By removing the Godot version number from the main menu (we have it in the About section now anyway) and moving the ui scale to the left in the main hamburger menu, it is a lot more stable in position and scale and allows for more subsequent clicks.

I also added this new scene to the top right of the setup wizard, giving the user an easy way of scaling the UI in the first experience in Resoto UI.