### PR TITLE
Only copy or navigate when clicking

### DIFF
--- a/src/components/dashboard/widget_table/widget_table_cell.gd
+++ b/src/components/dashboard/widget_table/widget_table_cell.gd
@@ -15,7 +15,7 @@ func _ready() -> void:
 	connect("mouse_exited", self, "on_mouse_exited")
 
 func _on_TableCell_gui_input(event):
-	if event is InputEventMouseButton and event.pressed:
+	if event is InputEventMouseButton and event.pressed and event.button_index == BUTTON_LEFT:
 		if node_id != "":
 			_g.emit_signal("explore_node_by_id", node_id)
 		else:


### PR DESCRIPTION
This fixes a bug that caused that scrolling on a table triggered a navigate or copy event.