### PR TITLE
Redesign aggregate search datasource UI

### DIFF
--- a/src/components/dashboard/data_sources/data_source_aggregate_search.gd
+++ b/src/components/dashboard/data_sources/data_source_aggregate_search.gd
@@ -49,6 +49,9 @@ func _on_aggregate_search_done(_error : int, response):
 
 
 func copy_data_source(other : AggregateSearchDataSource):
+	grouping_variables = other.grouping_variables
+	grouping_functions = other.grouping_functions
+	search_query = other.search_query
 	query = other.query
 
 

--- a/src/components/dashboard/data_sources/data_source_aggregate_search.gd
+++ b/src/components/dashboard/data_sources/data_source_aggregate_search.gd
@@ -1,8 +1,16 @@
 class_name AggregateSearchDataSource
 extends DataSource
 
+var grouping_variables := ""
+var grouping_functions := ""
+var search_query := ""
+
 func _init():
 	type = TYPES.AGGREGATE_SEARCH
+	
+
+func update_query():
+	query = 'aggregate(%s: %s): %s' % [grouping_variables, grouping_functions, search_query]
 
 func make_query(dashboard_filters : Dictionary, _attr : Dictionary):
 	var q : String = query

--- a/src/components/dashboard/data_sources/data_source_aggregate_search.gd
+++ b/src/components/dashboard/data_sources/data_source_aggregate_search.gd
@@ -12,6 +12,7 @@ func _init():
 func update_query():
 	query = 'aggregate(%s: %s): %s' % [grouping_variables, grouping_functions, search_query]
 
+
 func make_query(dashboard_filters : Dictionary, _attr : Dictionary):
 	var q : String = query
 
@@ -49,3 +50,13 @@ func _on_aggregate_search_done(_error : int, response):
 
 func copy_data_source(other : AggregateSearchDataSource):
 	query = other.query
+
+
+func get_data() -> Dictionary:
+	var data := {
+		"grouping_variables" : grouping_variables,
+		"grouping_functions" : grouping_functions,
+		"search_query" : search_query
+	}
+	data.merge(.get_data())
+	return data

--- a/src/components/dashboard/new_widget_popup/data_source_container.gd
+++ b/src/components/dashboard/new_widget_popup/data_source_container.gd
@@ -40,6 +40,9 @@ onready var kinds_combobox_two_entries_datasource := $VBox/TwoEntriesAggregate/K
 
 # Resulting Query Box
 onready var resulting_query_sep := $VBox/ResultingQueryBox
+onready var resulting_query_label := $VBox/ResultingQueryBox/QueryLabel
+
+onready var query_editbox_label := $VBox/QueryEditVBox/QueryLabel
 
 # Query Edit
 onready var query_edit := $VBox/QueryEditVBox/QueryEdit
@@ -54,22 +57,17 @@ func _ready() -> void:
 	$VBox/Search.visible = datasource_type == DataSource.TYPES.SEARCH
 	$VBox/TwoEntriesAggregate.visible = datasource_type == DataSource.TYPES.TWO_ENTRIES_AGGREGATE
 	$VBox/AggregateSearch.visible = datasource_type == DataSource.TYPES.AGGREGATE_SEARCH
-	show_query_separator(false)
 	update_time_series_sum_by()
 	
 	match datasource_type:
 		DataSource.TYPES.TIME_SERIES:
 			data_source = TimeSeriesDataSource.new()
-			show_query_separator(true)
 		DataSource.TYPES.AGGREGATE_SEARCH:
 			data_source = AggregateSearchDataSource.new()
-			show_query_separator(true)
 		DataSource.TYPES.SEARCH:
 			data_source = TextSearchDataSource.new()
-			show_query_separator(true)
 			API.cli_execute("kinds", self)
 		DataSource.TYPES.TWO_ENTRIES_AGGREGATE:
-			show_query_separator(true)
 			data_source = TwoEntryAggregateDataSource.new()
 			API.cli_execute("kinds", self)
 	
@@ -79,6 +77,7 @@ func _ready() -> void:
 	data_source.connect("query_status", self, "_on_data_source_query_status")
 	query_edit.connect("focus_exited", self, "_on_QueryEdit_focus_exited")
 	
+	update_query_label_text()
 	add_child(data_source)
 
 
@@ -309,8 +308,7 @@ func _on_ExpandButton_toggled(button_pressed:bool):
 	$VBox/Search.visible = button_pressed and datasource_type == DataSource.TYPES.SEARCH
 	$VBox/TwoEntriesAggregate.visible = button_pressed and datasource_type == DataSource.TYPES.TWO_ENTRIES_AGGREGATE
 	$VBox/AggregateSearch.visible = button_pressed and datasource_type == DataSource.TYPES.AGGREGATE_SEARCH
-	if [DataSource.TYPES.TWO_ENTRIES_AGGREGATE, DataSource.TYPES.SEARCH, DataSource.TYPES.TIME_SERIES].has(datasource_type):
-		show_query_separator(button_pressed)
+	show_query_separator(button_pressed)
 
 
 func _on_KindComboBox_option_changed(option):
@@ -371,7 +369,7 @@ func update_time_series_sum_by(last_metric_keys:Array=[]):
 
 func show_query_separator(_show:bool=false):
 	resulting_query_sep.visible = _show
-	$VBox/QueryEditVBox/QueryLabel.visible = !_show
+	query_editbox_label.visible = !_show
 
 
 func _on_GroupVariables_group_variables_changed(grouping_variables):
@@ -387,3 +385,17 @@ func _on_GroupFunctions_group_variables_changed(grouping_variables):
 func _on_AggregateSearchQuery_text_entered(new_text):
 	data_source.search_query = new_text
 	update_query()
+
+
+func update_query_label_text():
+	var label_text : String = ""
+	match datasource_type:
+		DataSource.TYPES.TIME_SERIES:
+			label_text = "Query"
+		DataSource.TYPES.SEARCH:
+			label_text = "Resoto Search"
+		_:
+			label_text = "Aggregate Search"
+			
+	query_editbox_label.text = label_text
+	resulting_query_label.text = label_text

--- a/src/components/dashboard/new_widget_popup/data_source_container.gd
+++ b/src/components/dashboard/new_widget_popup/data_source_container.gd
@@ -53,6 +53,7 @@ func _ready() -> void:
 	$VBox/TimeSeries.visible = datasource_type == DataSource.TYPES.TIME_SERIES
 	$VBox/Search.visible = datasource_type == DataSource.TYPES.SEARCH
 	$VBox/TwoEntriesAggregate.visible = datasource_type == DataSource.TYPES.TWO_ENTRIES_AGGREGATE
+	$VBox/AggregateSearch.visible = datasource_type == DataSource.TYPES.AGGREGATE_SEARCH
 	show_query_separator(false)
 	update_time_series_sum_by()
 	
@@ -62,7 +63,7 @@ func _ready() -> void:
 			show_query_separator(true)
 		DataSource.TYPES.AGGREGATE_SEARCH:
 			data_source = AggregateSearchDataSource.new()
-			expand_button.hide()
+			show_query_separator(true)
 		DataSource.TYPES.SEARCH:
 			data_source = TextSearchDataSource.new()
 			show_query_separator(true)
@@ -307,6 +308,7 @@ func _on_ExpandButton_toggled(button_pressed:bool):
 	$VBox/TimeSeries.visible = button_pressed and datasource_type == DataSource.TYPES.TIME_SERIES
 	$VBox/Search.visible = button_pressed and datasource_type == DataSource.TYPES.SEARCH
 	$VBox/TwoEntriesAggregate.visible = button_pressed and datasource_type == DataSource.TYPES.TWO_ENTRIES_AGGREGATE
+	$VBox/AggregateSearch.visible = button_pressed and datasource_type == DataSource.TYPES.AGGREGATE_SEARCH
 	if [DataSource.TYPES.TWO_ENTRIES_AGGREGATE, DataSource.TYPES.SEARCH, DataSource.TYPES.TIME_SERIES].has(datasource_type):
 		show_query_separator(button_pressed)
 
@@ -370,3 +372,18 @@ func update_time_series_sum_by(last_metric_keys:Array=[]):
 func show_query_separator(_show:bool=false):
 	resulting_query_sep.visible = _show
 	$VBox/QueryEditVBox/QueryLabel.visible = !_show
+
+
+func _on_GroupVariables_group_variables_changed(grouping_variables):
+	data_source.grouping_variables = grouping_variables
+	update_query()
+
+
+func _on_GroupFunctions_group_variables_changed(grouping_variables):
+	data_source.grouping_functions = grouping_variables
+	update_query()
+
+
+func _on_AggregateSearchQuery_text_entered(new_text):
+	data_source.search_query = new_text
+	update_query()

--- a/src/components/dashboard/new_widget_popup/data_source_container.gd
+++ b/src/components/dashboard/new_widget_popup/data_source_container.gd
@@ -35,7 +35,10 @@ onready var function_line_edit := $VBox/TwoEntriesAggregate/FunctionContainer/Fu
 onready var function_alias_line_edit := $VBox/TwoEntriesAggregate/FunctionContainer/FunctionAlias
 onready var kinds_combobox_two_entries_datasource := $VBox/TwoEntriesAggregate/KindComboBox
 
-# Aggregation would make sense!
+# Aggregate Search
+onready var group_variables := $VBox/AggregateSearch/GroupVariables
+onready var group_functions := $VBox/AggregateSearch/GroupFunctions
+onready var search_query := $VBox/AggregateSearch/AggregateSearchQuery
 
 
 # Resulting Query Box
@@ -268,6 +271,10 @@ func set_data_source(new_data_source : DataSource) -> void:
 			function_line_edit.text = new_data_source.function
 			function_alias_line_edit.text = new_data_source.function_alias
 			kinds_combobox_two_entries_datasource.text = new_data_source.kind 
+		DataSource.TYPES.AGGREGATE_SEARCH:
+			group_variables.grouping_variables = data_source.grouping_variables
+			group_functions.grouping_variables = data_source.grouping_functions
+			search_query.text = data_source.search_query
 			
 	$VBox/Title/ExpandButton.pressed = !new_data_source.custom_query
 	show_query_separator(!new_data_source.custom_query)

--- a/src/components/dashboard/new_widget_popup/data_source_container.tscn
+++ b/src/components/dashboard/new_widget_popup/data_source_container.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://components/dashboard/new_widget_popup/filter_widget.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/icons/icon_128_collapse.svg" type="Texture" id=2]
 [ext_resource path="res://assets/icons/icon_128_expand.svg" type="Texture" id=3]
 [ext_resource path="res://assets/icons/icon_128_delete_trashcan.svg" type="Texture" id=4]
+[ext_resource path="res://components/dashboard/new_widget_popup/group_variables_widget.tscn" type="PackedScene" id=5]
 [ext_resource path="res://components/elements/utility/line_edit_update_on_focus_lost.gd" type="Script" id=6]
 [ext_resource path="res://components/dashboard/new_widget_popup/data_source_container.gd" type="Script" id=7]
 [ext_resource path="res://assets/theme/dark_theme.tres" type="Theme" id=8]
@@ -51,7 +52,7 @@ script = ExtResource( 7 )
 margin_left = 6.0
 margin_top = 6.0
 margin_right = 517.0
-margin_bottom = 593.0
+margin_bottom = 349.0
 
 [node name="Title" type="HBoxContainer" parent="VBox"]
 margin_right = 511.0
@@ -102,6 +103,7 @@ size_flags_vertical = 1
 icon_tex = ExtResource( 4 )
 
 [node name="TimeSeries" type="VBoxContainer" parent="VBox"]
+visible = false
 margin_top = 37.0
 margin_right = 511.0
 margin_bottom = 247.0
@@ -245,9 +247,8 @@ script = ExtResource( 6 )
 
 [node name="Search" type="VBoxContainer" parent="VBox"]
 visible = false
-margin_top = 37.0
 margin_right = 511.0
-margin_bottom = 250.0
+margin_bottom = 213.0
 
 [node name="Label" type="Label" parent="VBox/Search"]
 margin_right = 511.0
@@ -320,9 +321,10 @@ margin_bottom = 249.0
 script = ExtResource( 6 )
 
 [node name="TwoEntriesAggregate" type="VBoxContainer" parent="VBox"]
-margin_top = 251.0
+visible = false
+margin_top = 37.0
 margin_right = 511.0
-margin_bottom = 487.0
+margin_bottom = 273.0
 
 [node name="Label" type="Label" parent="VBox/TwoEntriesAggregate"]
 margin_right = 511.0
@@ -490,10 +492,38 @@ margin_bottom = 32.0
 size_flags_horizontal = 3
 script = ExtResource( 6 )
 
-[node name="ResultingQueryBox" type="HBoxContainer" parent="VBox"]
-margin_top = 491.0
+[node name="AggregateSearch" type="VBoxContainer" parent="VBox"]
+visible = false
 margin_right = 511.0
-margin_bottom = 511.0
+margin_bottom = 160.0
+
+[node name="GroupVariables" parent="VBox/AggregateSearch" instance=ExtResource( 5 )]
+margin_right = 511.0
+margin_bottom = 48.0
+
+[node name="GroupFunctions" parent="VBox/AggregateSearch" instance=ExtResource( 5 )]
+margin_top = 52.0
+margin_right = 511.0
+margin_bottom = 100.0
+title = "Grouping Functions"
+element_name = "Function"
+
+[node name="Label" type="Label" parent="VBox/AggregateSearch"]
+margin_top = 104.0
+margin_right = 511.0
+margin_bottom = 124.0
+text = "Search Query"
+
+[node name="AggregateSearchQuery" type="LineEdit" parent="VBox/AggregateSearch"]
+margin_top = 128.0
+margin_right = 511.0
+margin_bottom = 160.0
+script = ExtResource( 6 )
+
+[node name="ResultingQueryBox" type="HBoxContainer" parent="VBox"]
+margin_top = 37.0
+margin_right = 511.0
+margin_bottom = 57.0
 
 [node name="Label" type="Label" parent="VBox/ResultingQueryBox"]
 margin_right = 118.0
@@ -508,9 +538,9 @@ margin_bottom = 20.0
 size_flags_horizontal = 3
 
 [node name="QueryEditVBox" type="VBoxContainer" parent="VBox"]
-margin_top = 515.0
+margin_top = 61.0
 margin_right = 511.0
-margin_bottom = 587.0
+margin_bottom = 133.0
 
 [node name="QueryLabel" type="Label" parent="VBox/QueryEditVBox"]
 visible = false
@@ -562,6 +592,9 @@ custom_styles/panel = SubResource( 2 )
 [connection signal="text_entered" from="VBox/TwoEntriesAggregate/EntryContainer2/Entry2Alias" to="." method="_on_Entry2Alias_text_entered"]
 [connection signal="text_entered" from="VBox/TwoEntriesAggregate/FunctionContainer/FunctionLineEdit" to="." method="_on_FunctionLineEdit_text_entered"]
 [connection signal="text_entered" from="VBox/TwoEntriesAggregate/FunctionContainer/FunctionAlias" to="." method="_on_FunctionAlias_text_entered"]
+[connection signal="group_variables_changed" from="VBox/AggregateSearch/GroupVariables" to="." method="_on_GroupVariables_group_variables_changed"]
+[connection signal="group_variables_changed" from="VBox/AggregateSearch/GroupFunctions" to="." method="_on_GroupFunctions_group_variables_changed"]
+[connection signal="text_entered" from="VBox/AggregateSearch/AggregateSearchQuery" to="." method="_on_AggregateSearchQuery_text_entered"]
 [connection signal="cursor_changed" from="VBox/QueryEditVBox/QueryEdit" to="." method="_on_QueryEdit_cursor_changed"]
 [connection signal="gui_input" from="VBox/QueryEditVBox/QueryEdit" to="." method="_on_QueryEdit_gui_input"]
 [connection signal="item_rect_changed" from="VBox/QueryEditVBox/QueryEdit" to="." method="_on_QueryEdit_item_rect_changed"]

--- a/src/components/dashboard/new_widget_popup/data_source_container.tscn
+++ b/src/components/dashboard/new_widget_popup/data_source_container.tscn
@@ -525,14 +525,14 @@ margin_top = 37.0
 margin_right = 511.0
 margin_bottom = 57.0
 
-[node name="Label" type="Label" parent="VBox/ResultingQueryBox"]
-margin_right = 118.0
+[node name="QueryLabel" type="Label" parent="VBox/ResultingQueryBox"]
+margin_right = 136.0
 margin_bottom = 20.0
 theme_type_variation = "LabelBold"
-text = "Resulting Query"
+text = "Aggregate Search"
 
 [node name="HSeparator" type="HSeparator" parent="VBox/ResultingQueryBox"]
-margin_left = 122.0
+margin_left = 140.0
 margin_right = 511.0
 margin_bottom = 20.0
 size_flags_horizontal = 3

--- a/src/components/dashboard/new_widget_popup/group_variables_element.gd
+++ b/src/components/dashboard/new_widget_popup/group_variables_element.gd
@@ -1,0 +1,29 @@
+extends GridContainer
+
+signal element_changed
+
+var element_name := "Grouping Variable"
+
+onready var group_variable_line_edit := $GroupingVariableLineEdit
+onready var alias_line_edit := $AliasLineEdit
+
+func _ready():
+	$Label.text = element_name
+
+func get_grouping_variable() -> String:
+	var group_variable : String = group_variable_line_edit.text
+	if alias_line_edit.text != "":
+		group_variable += " as %s" % alias_line_edit.text
+		
+	return group_variable
+
+func _on_DeleteFilterButton_pressed():
+	queue_free()
+
+
+func _on_GroupingVariableLineEdit_text_entered(_new_text):
+	emit_signal("element_changed")
+
+
+func _on_AliasLineEdit_text_entered(_new_text):
+	emit_signal("element_changed")

--- a/src/components/dashboard/new_widget_popup/group_variables_element.gd
+++ b/src/components/dashboard/new_widget_popup/group_variables_element.gd
@@ -4,6 +4,10 @@ signal element_changed
 
 var element_name := "Grouping Variable"
 
+# Just for loading templates
+var variable : String = "" setget set_variable
+var alias : String = "" setget set_alias
+
 onready var group_variable_line_edit := $GroupingVariableLineEdit
 onready var alias_line_edit := $AliasLineEdit
 
@@ -26,4 +30,16 @@ func _on_GroupingVariableLineEdit_text_entered(_new_text):
 
 
 func _on_AliasLineEdit_text_entered(_new_text):
+	emit_signal("element_changed")
+
+
+func set_variable(_variable : String):
+	variable = _variable
+	group_variable_line_edit.text = variable
+	emit_signal("element_changed")
+
+
+func set_alias(_alias : String):
+	alias = _alias
+	alias_line_edit.text = alias
 	emit_signal("element_changed")

--- a/src/components/dashboard/new_widget_popup/group_variables_element.tscn
+++ b/src/components/dashboard/new_widget_popup/group_variables_element.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://assets/icons/icon_128_delete_trashcan.svg" type="Texture" id=1]
+[ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=2]
+[ext_resource path="res://components/dashboard/new_widget_popup/group_variables_element.gd" type="Script" id=3]
+[ext_resource path="res://components/elements/utility/line_edit_update_on_focus_lost.gd" type="Script" id=4]
+
+[node name="GroupVariablesElement" type="GridContainer"]
+margin_right = 352.0
+margin_bottom = 56.0
+columns = 4
+script = ExtResource( 3 )
+
+[node name="Label" type="Label" parent="."]
+margin_right = 150.0
+margin_bottom = 15.0
+theme_type_variation = "LabelSmall"
+text = "Grouping variable"
+
+[node name="Spacer" type="Control" parent="."]
+margin_left = 154.0
+margin_right = 171.0
+margin_bottom = 15.0
+
+[node name="Label2" type="Label" parent="."]
+margin_left = 175.0
+margin_right = 324.0
+margin_bottom = 15.0
+theme_type_variation = "LabelSmall"
+text = "Alias"
+
+[node name="Spacer2" type="Control" parent="."]
+margin_left = 328.0
+margin_right = 352.0
+margin_bottom = 15.0
+
+[node name="GroupingVariableLineEdit" type="LineEdit" parent="."]
+margin_top = 19.0
+margin_right = 150.0
+margin_bottom = 56.0
+size_flags_horizontal = 3
+script = ExtResource( 4 )
+
+[node name="Label3" type="Label" parent="."]
+margin_left = 154.0
+margin_top = 27.0
+margin_right = 171.0
+margin_bottom = 47.0
+text = "as"
+
+[node name="AliasLineEdit" type="LineEdit" parent="."]
+margin_left = 175.0
+margin_top = 19.0
+margin_right = 324.0
+margin_bottom = 56.0
+size_flags_horizontal = 3
+script = ExtResource( 4 )
+
+[node name="DeleteFilterButton" parent="." instance=ExtResource( 2 )]
+margin_left = 328.0
+margin_top = 19.0
+margin_right = 352.0
+margin_bottom = 56.0
+rect_min_size = Vector2( 24, 28 )
+hint_tooltip = "Add Filter"
+icon_tex = ExtResource( 1 )
+icon_margin = 1
+
+[connection signal="text_entered" from="GroupingVariableLineEdit" to="." method="_on_GroupingVariableLineEdit_text_entered"]
+[connection signal="text_entered" from="AliasLineEdit" to="." method="_on_AliasLineEdit_text_entered"]
+[connection signal="pressed" from="DeleteFilterButton" to="." method="_on_DeleteFilterButton_pressed"]

--- a/src/components/dashboard/new_widget_popup/group_variables_widget.gd
+++ b/src/components/dashboard/new_widget_popup/group_variables_widget.gd
@@ -7,7 +7,7 @@ const GroupVariablesElement := preload("res://components/dashboard/new_widget_po
 export (String) var title := "Grouping Variables" setget set_title
 export (String) var element_name := "Grouping Variable"
 
-var grouping_variables := ""
+var grouping_variables := "" setget set_grouping_variables
 
 onready var variables_container := $VBoxContainer/Margin/VariablesContainer
 onready var update_delay := $UpdateDelay
@@ -18,11 +18,16 @@ func _ready():
 
 
 func _on_AddVariableButton_pressed():
+	var __ = add_grouping_variable_element()
+
+
+func add_grouping_variable_element():
 	var variable := GroupVariablesElement.instance()
 	variable.connect("element_changed", self, "update_grouping_variables")
 	variable.connect("tree_exited", self, "update_grouping_variables")
 	variable.element_name = element_name
 	variables_container.add_child(variable)
+	return variable
 
 
 func update_grouping_variables():
@@ -36,7 +41,8 @@ func update_grouping_variables():
 
 func _on_UpdateDelay_timeout():
 	emit_signal("group_variables_changed", grouping_variables)
-	
+
+
 func set_title(_title : String):
 	title = _title
 	if not is_inside_tree():
@@ -47,3 +53,18 @@ func set_title(_title : String):
 func _on_group_variables_widget_tree_exiting():
 	for variable in variables_container.get_children():
 		variable.disconnect("tree_exited", self, "update_grouping_variables")
+
+
+func set_grouping_variables(_grouping_variables : String):
+	for element in variables_container.get_children():
+		variables_container.remove_child(element)
+		element.queue_free()
+	grouping_variables = _grouping_variables
+	var grouping_variables_array = grouping_variables.split(",")
+	for v in grouping_variables_array:
+		var element = add_grouping_variable_element()
+		var var_array = v.split(" as ")
+		element.variable = var_array[0].trim_prefix(" ").trim_suffix(" ")
+		if var_array.size() > 1:
+			element.alias = var_array[1].trim_prefix(" ").trim_suffix(" ")
+	

--- a/src/components/dashboard/new_widget_popup/group_variables_widget.gd
+++ b/src/components/dashboard/new_widget_popup/group_variables_widget.gd
@@ -1,0 +1,49 @@
+extends PanelContainer
+
+signal group_variables_changed(grouping_variables)
+
+const GroupVariablesElement := preload("res://components/dashboard/new_widget_popup/group_variables_element.tscn")
+
+export (String) var title := "Grouping Variables" setget set_title
+export (String) var element_name := "Grouping Variable"
+
+var grouping_variables := ""
+
+onready var variables_container := $VBoxContainer/Margin/VariablesContainer
+onready var update_delay := $UpdateDelay
+
+
+func _ready():
+	set_title(title)
+
+
+func _on_AddVariableButton_pressed():
+	var variable := GroupVariablesElement.instance()
+	variable.connect("element_changed", self, "update_grouping_variables")
+	variable.connect("tree_exited", self, "update_grouping_variables")
+	variable.element_name = element_name
+	variables_container.add_child(variable)
+
+
+func update_grouping_variables():
+	var grouping_variables_array : PoolStringArray = []
+	for element in variables_container.get_children():
+		grouping_variables_array.append(element.get_grouping_variable())
+		
+	grouping_variables = grouping_variables_array.join(", ")
+	update_delay.start()
+
+
+func _on_UpdateDelay_timeout():
+	emit_signal("group_variables_changed", grouping_variables)
+	
+func set_title(_title : String):
+	title = _title
+	if not is_inside_tree():
+		return
+	$VBoxContainer/Headline/Label.text = title
+
+
+func _on_group_variables_widget_tree_exiting():
+	for variable in variables_container.get_children():
+		variable.disconnect("tree_exited", self, "update_grouping_variables")

--- a/src/components/dashboard/new_widget_popup/group_variables_widget.tscn
+++ b/src/components/dashboard/new_widget_popup/group_variables_widget.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=1]
+[ext_resource path="res://assets/icons/icon_128_add.svg" type="Texture" id=2]
+[ext_resource path="res://components/dashboard/new_widget_popup/group_variables_widget.gd" type="Script" id=3]
+
+[node name="group_variables_widget" type="PanelContainer"]
+margin_right = 20.0
+margin_bottom = 20.0
+script = ExtResource( 3 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 184.0
+margin_bottom = 38.0
+size_flags_horizontal = 3
+custom_constants/separation = -5
+
+[node name="Headline" type="HBoxContainer" parent="VBoxContainer"]
+margin_right = 174.0
+margin_bottom = 33.0
+
+[node name="Label" type="Label" parent="VBoxContainer/Headline"]
+margin_right = 141.0
+margin_bottom = 33.0
+rect_min_size = Vector2( 0, 33 )
+theme_type_variation = "LabelBold"
+text = "Grouping Variables"
+valign = 1
+
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer/Headline"]
+modulate = Color( 1, 1, 1, 0.501961 )
+margin_left = 145.0
+margin_right = 148.0
+margin_bottom = 33.0
+size_flags_horizontal = 3
+
+[node name="AddVariableButton" parent="VBoxContainer/Headline" instance=ExtResource( 1 )]
+margin_left = 152.0
+margin_right = 174.0
+rect_min_size = Vector2( 22, 33 )
+size_flags_vertical = 4
+icon_tex = ExtResource( 2 )
+icon_margin = 2
+
+[node name="Margin" type="MarginContainer" parent="VBoxContainer"]
+margin_top = 28.0
+margin_right = 174.0
+margin_bottom = 28.0
+custom_constants/margin_right = 0
+custom_constants/margin_top = 0
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 0
+
+[node name="VariablesContainer" type="VBoxContainer" parent="VBoxContainer/Margin"]
+margin_left = 10.0
+margin_right = 174.0
+custom_constants/separation = 1
+
+[node name="UpdateDelay" type="Timer" parent="."]
+wait_time = 0.1
+one_shot = true
+
+[connection signal="tree_exiting" from="." to="." method="_on_group_variables_widget_tree_exiting"]
+[connection signal="pressed" from="VBoxContainer/Headline/AddVariableButton" to="." method="_on_AddVariableButton_pressed"]
+[connection signal="timeout" from="UpdateDelay" to="." method="_on_UpdateDelay_timeout"]

--- a/src/data/data_sources_templates.json
+++ b/src/data/data_sources_templates.json
@@ -36,6 +36,9 @@
         "Widgets": ["Table", "Heatmap"],
         "data": {
             "type": 1,
+            "search_query": "is(instance)",
+            "grouping_variables": "kind, /ancestors.cloud.reported.name",
+            "grouping_functions": "sum(1) as nodes",
             "query": "aggregate(kind, /ancestors.cloud.reported.name: sum(1) as nodes): is(instance)"
         }
     },
@@ -45,6 +48,9 @@
         "Description": "Gets the number of instances per instance type and account name",
         "data": {
             "type": 1,
+            "search_query": "is(instance)",
+            "grouping_variables": "instance_type, /ancestors.account.reported.name",
+            "grouping_functions": "sum(1) as instances",
             "query": "aggregate(instance_type, /ancestors.account.reported.name: sum(1) as instances): is(instance)"
         }
     },


### PR DESCRIPTION
This PR redesigns the ui for adding an aggregate data source, and also changes the resulting query label text to something that matches the data-source type:

- Time Series Datasource -> Query
- Search Data Source -> Resoto Search
- The rest of them -> Aggregate Search