### PR TITLE
Fix problem when the Resh Lite popup and Resh Lite component are opened

### DIFF
--- a/src/components/elements/styled/custom_dragable_window_panel.gd
+++ b/src/components/elements/styled/custom_dragable_window_panel.gd
@@ -25,6 +25,7 @@ var pos_before_max:= Vector2.ONE
 var is_resizing:= false
 var orig_size:= Vector2.ONE
 var resize_click_origin:= Vector2.ONE
+var content:Node = null
 
 onready var max_btn = $Content/Titlebar/Label/TitleButtons/MaximizeButton
 onready var close_btn = $Content/Titlebar/Label/TitleButtons/CloseButton
@@ -47,6 +48,7 @@ func _ready():
 	$Content/Footer.visible = show_footer
 	if window_content != null:
 		var new_content = window_content.instance()
+		content = new_content
 		$Content/Content.add_child(new_content)
 
 

--- a/src/components/terminal/component_terminal.gd
+++ b/src/components/terminal/component_terminal.gd
@@ -5,6 +5,8 @@ signal rename_terminal
 
 const MODIFIER_KEYS:Array = [KEY_CONTROL, KEY_SHIFT, KEY_ALT, KEY_CAPSLOCK, KEY_META, KEY_MASK_META, KEY_MASK_CMD]
 
+export var is_popup := false
+
 var terminal_active: bool = false setget set_terminal_active
 var last_command_id: int  = -1
 var current_command:String = ""
@@ -74,6 +76,8 @@ func _input(event:InputEvent) -> void:
 		return
 	
 	if not command.has_focus() and event.pressed and not MODIFIER_KEYS.has(event.scancode) and event.scancode != KEY_ESCAPE:
+		if not is_popup and _g.popup_manager.resh_lite_popup.visible:
+			return
 		just_grabbed_focus = true
 		yield(get_tree(), "idle_frame")
 		console.selection_enabled = false

--- a/src/scripts/ui_popup_manager.gd
+++ b/src/scripts/ui_popup_manager.gd
@@ -5,6 +5,7 @@ signal popup_gone
 
 var current_popup: Popup = null
 var popup_connect: Node = null
+var resh_lite_popup : Node = null
 
 var tooltip_link_active:= false
 var tooltip_active:= false

--- a/src/scripts/ui_terminal_manager.gd
+++ b/src/scripts/ui_terminal_manager.gd
@@ -2,6 +2,8 @@ extends VBoxContainer
 
 var TerminalScene: PackedScene = preload("res://components/terminal/component_terminal.tscn")
 
+var is_popup := false
+
 var terminals: Array = []
 var _active_tab_id: int = -1
 
@@ -38,6 +40,7 @@ func change_name(_new_name:String) -> void:
 func add_new_terminal_tab() -> void:
 	tabs.add_tab("Terminal " + str(tabs.get_tab_count()+1))
 	var new_terminal = TerminalScene.instance()
+	new_terminal.is_popup = is_popup
 	new_terminal.connect("rename_terminal", self, "on_rename_terminal", [new_terminal])
 	terminals.append(new_terminal)
 	container.add_child(new_terminal)

--- a/src/scripts/ui_terminal_popup.gd
+++ b/src/scripts/ui_terminal_popup.gd
@@ -9,6 +9,8 @@ onready var terminal_popup := $TerminalPanel
 onready var tween = $VisibilityTween
 
 func _ready():
+	_g.popup_manager.resh_lite_popup = terminal_popup
+	terminal_popup.content.is_popup = true
 	terminal_popup.modulate.a = 0.0
 	_g.connect("resh_lite_popup", self, "change_terminal_popup_visibility")
 	_g.connect("resh_lite_popup_hide", self, "hide_terminal_popup")


### PR DESCRIPTION
If they are both opened at the same time, they fight to grab the input and go haywire.