### PR TITLE
Added raw view to Config Editor and fixed a crash with incomplete model

### DIFF
--- a/src/components/config/component_config.gd
+++ b/src/components/config/component_config.gd
@@ -37,7 +37,7 @@ var active_config_key : String = ""
 var active_config : Dictionary
 var config_page : Control = null
 
-var show_dashboards : bool = false
+var use_raw_mode : bool = false
 
 var tabs_content : Dictionary = {}
 var tabs_content_keys : Array = []
@@ -186,6 +186,10 @@ func _on_get_config_id_done(_error:int, _response:ResotoAPI.Response, _config_ke
 
 
 func build_config_page():
+	if not use_raw_mode:
+		$"%RawViewModeButton".set_pressed(false, false)
+		$"%RawViewModeButton".disabled = false
+		$"%RawViewMapTitle".modulate.a = 1
 	var new_config_page = add_new_config_page(active_config_key)
 	new_config_page.set_meta("main_level", true)
 	new_config_page.key = active_config_key
@@ -196,6 +200,9 @@ func build_config_page():
 	
 	# If the config is completely empty, just add a raw json display
 	if active_config.keys().empty():
+		$"%RawViewModeButton".set_pressed(true, false)
+		$"%RawViewModeButton".disabled = true
+		$"%RawViewMapTitle".modulate.a = 0.3
 		var new_element = add_element("_", "", {}, new_config_page, false)
 		new_elements.append(new_element)
 	else:
@@ -312,14 +319,14 @@ func add_element(_name:String, kind:String, _property_value, _parent:Control, de
 	var model_search = find_in_model(kind)
 	var model = model_search[1]
 	
-	if BASE_KINDS.has(kind):
+	if BASE_KINDS.has(kind) and not use_raw_mode:
 		# Create a new "Simple"
 		var simple_property = null
 		if _parent.model and _parent.model.has("properties"):
 			simple_property = find_in_properties(_parent.model.properties, _name)
 		return create_simple(_name, _property_value, kind, simple_property, _parent, default)
 	
-	elif kind.begins_with("dictionary") and not kind.ends_with("[]"):
+	elif kind.begins_with("dictionary") and not kind.ends_with("[]") and not use_raw_mode:
 		# Create a new Dictionary 
 #		print("=> Dict :", _name, ">", kind)
 		var simple_property = null
@@ -327,21 +334,21 @@ func add_element(_name:String, kind:String, _property_value, _parent:Control, de
 			simple_property = find_in_properties(_parent.model.properties, _name)
 		return create_dict(_name, kind, _property_value, simple_property, _parent, default)
 	
-	elif kind.ends_with("[]"):
+	elif kind.ends_with("[]") and not use_raw_mode:
 		# Create a new Array
 		var simple_property = null
 		if _parent.model and _parent.model.has("properties"):
 			simple_property = find_in_properties(_parent.model.properties, _name)
 		return create_array(_name, _property_value, kind, simple_property, _parent, default)
 	
-	elif model and model.has("enum"):
+	elif model and model.has("enum") and not use_raw_mode:
 		# Create a new Enum selection field
 		var simple_property = null
 		if _parent.model and _parent.model.has("properties"):
 			simple_property = find_in_properties(_parent.model.properties, _name)
 		return create_enum(_name, _property_value, kind, simple_property, model.enum, _parent, default)
 	
-	elif model and model.has("properties"):
+	elif model and model.has("properties") and not use_raw_mode:
 		# Create a new Complex, either by scratch or with values.
 		var new_elements:Array = []
 		if not default:
@@ -353,9 +360,19 @@ func add_element(_name:String, kind:String, _property_value, _parent:Control, de
 				
 				if element_property.empty():
 					var element_model_search = find_in_model(key)
-					var element_model = element_model_search[1].properties
-					var element_kind:String = key if not (element_model and element_model.has("kind")) else element_model.kind
-					new_elements.append( create_complex(key, element_kind, element, element_model, _parent, default) )
+					if element_model_search[1] != null:
+						var element_model = element_model_search[1].properties
+						var element_kind:String = key if not (element_model and element_model.has("kind")) else element_model.kind
+						new_elements.append( create_complex(key, element_kind, element, element_model, _parent, default) )
+					else:
+						# If there is a problem with the model / data, use the raw view as fallback
+						_g.emit_signal("add_toast", "Config Model Error", "The current configuration has properties not described in the model, fallback raw view will be used.", 1, self)
+						use_raw_mode = true
+						$"%RawViewModeButton".set_pressed(true, false)
+						$"%RawViewModeButton".disabled = true
+						$"%RawViewMapTitle".modulate.a = 0.3
+						open_configuration(active_config_key)
+						return
 				else:
 					if is_fqn(element_property.kind):
 						new_elements.append( create_complex(key, element_property.kind, element, element_property, _parent, default) )
@@ -371,7 +388,13 @@ func add_element(_name:String, kind:String, _property_value, _parent:Control, de
 			pass
 		return new_elements
 	else:
-		var error_message = "Configuration was not found in model.\nDisplaying configurations in raw JSON:"
+		var error_message = ""
+		if not use_raw_mode:
+			error_message = "Configuration was not found in model.\nDisplaying configurations in raw JSON:"
+			$"%RawViewModeButton".set_pressed(true, false)
+			$"%RawViewModeButton".disabled = true
+			$"%RawViewMapTitle".modulate.a = 0.3
+		use_raw_mode = false
 		return create_custom(error_message, _property_value, _parent)
 
 
@@ -759,6 +782,6 @@ func _on_rename_confirm_response(_button_clicked:String, _value:String):
 		active_config_key = rename_new_name
 
 
-func _on_ShowDashboardsButton_toggled(button_pressed):
-	show_dashboards = button_pressed
-	load_configs()
+func _on_RawViewModeButton_toggled(_pressed):
+	use_raw_mode = _pressed
+	open_configuration(active_config_key)

--- a/src/components/config/component_config.tscn
+++ b/src/components/config/component_config.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://components/config/component_config.gd" type="Script" id=1]
 [ext_resource path="res://assets/theme/dark_theme.tres" type="Theme" id=2]
+[ext_resource path="res://assets/icons/icon_128_save_disc.svg" type="Texture" id=3]
+[ext_resource path="res://components/elements/styled/icon_button_text.tscn" type="PackedScene" id=4]
+[ext_resource path="res://components/elements/styled/check_button_styled.tscn" type="PackedScene" id=5]
 [ext_resource path="res://components/elements/utility/scroll_container_scrollbar_claim_space_vertical.gd" type="Script" id=8]
 [ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=12]
 [ext_resource path="res://assets/icons/icon_128_delete_trashcan.svg" type="Texture" id=13]
@@ -80,20 +83,37 @@ flat = true
 
 [node name="Spacer" type="Control" parent="VBox/Toolbar/Box"]
 margin_left = 124.0
-margin_right = 1613.0
+margin_right = 1445.0
 margin_bottom = 33.0
 rect_min_size = Vector2( 20, 0 )
 size_flags_horizontal = 3
 
-[node name="SaveConfigButton" type="Button" parent="VBox/Toolbar/Box"]
-margin_left = 1616.0
-margin_top = 1.0
-margin_right = 1726.67
-margin_bottom = 33.0
-hint_tooltip = "Save this configuration in Resoto Core"
-size_flags_horizontal = 4
-size_flags_vertical = 8
+[node name="RawViewModeButton" parent="VBox/Toolbar/Box" instance=ExtResource( 5 )]
+unique_name_in_owner = true
+margin_left = 1449.0
+margin_top = 6.0
+margin_right = 1484.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 35, 20 )
+size_flags_vertical = 4
+
+[node name="RawViewMapTitle" type="Label" parent="VBox/Toolbar/Box"]
+unique_name_in_owner = true
+margin_left = 1488.0
+margin_top = 6.0
+margin_right = 1588.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 100, 0 )
+text = "Raw View"
+
+[node name="SaveConfigButton" parent="VBox/Toolbar/Box" instance=ExtResource( 4 )]
+margin_left = 1592.0
+margin_right = 1727.0
+rect_min_size = Vector2( 135, 33 )
 text = "Save Config"
+align = 2
+icon_tex = ExtResource( 3 )
+icon_margin = 4
 
 [node name="RenameConfigButton" parent="VBox/Toolbar/Box" instance=ExtResource( 12 )]
 margin_left = 1731.0
@@ -190,6 +210,7 @@ custom_constants/margin_left = 8
 
 [connection signal="option_changed" from="VBox/Toolbar/Box/ConfigCombo" to="." method="_on_ConfigCombo_option_changed"]
 [connection signal="toggled" from="VBox/Toolbar/Box/ShowDashboardsButton" to="." method="_on_ShowDashboardsButton_toggled"]
+[connection signal="toggled" from="VBox/Toolbar/Box/RawViewModeButton" to="." method="_on_RawViewModeButton_toggled"]
 [connection signal="pressed" from="VBox/Toolbar/Box/SaveConfigButton" to="." method="_on_SaveConfigButton_pressed"]
 [connection signal="pressed" from="VBox/Toolbar/Box/RenameConfigButton" to="." method="_on_RenameConfigButton_pressed"]
 [connection signal="pressed" from="VBox/Toolbar/Box/DuplicateConfigButton" to="." method="_on_DuplicateConfigButton_pressed"]

--- a/src/components/config/config_templates/component_config_enum.gd
+++ b/src/components/config/config_templates/component_config_enum.gd
@@ -66,16 +66,10 @@ func get_value():
 	return value
 
 
-func _make_custom_tooltip(for_text):
-	var tooltip = preload("res://components/shared/custom_bb_hint_tooltip.tscn").instance()
-	tooltip.get_node("Text").set_bbcode(for_text)
-	return tooltip
-
-
 func set_description(_value:String) -> void:
 	description = _value
 	if descriptions_as_hints:
-		hint_tooltip = "[b]Property:[/b]\n[code]%s[/code]\n\n%s" % [key, description]
+		$VarContent/HintIcon.hint = "[b]Property:[/b]\n[code]%s[/code]\n\n%s" % [key, description]
 		return
 	if _value == "":
 		$Description.hide()

--- a/src/components/config/config_templates/component_config_template_enum.tscn
+++ b/src/components/config/config_templates/component_config_template_enum.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://components/config/config_templates/component_config_enum.gd" type="Script" id=1]
 [ext_resource path="res://assets/icons/icon_128_add.svg" type="Texture" id=2]
 [ext_resource path="res://components/elements/styled/icon_button.tscn" type="PackedScene" id=3]
 [ext_resource path="res://assets/icons/icon_128_to_null.svg" type="Texture" id=4]
+[ext_resource path="res://components/config/config_templates/config_custom_tooltip.gd" type="Script" id=5]
+[ext_resource path="res://assets/icons/icon_128_info_circle.svg" type="Texture" id=6]
 
 [sub_resource type="DynamicFontData" id=2]
 font_path = "res://assets/theme/Barlow-Regular.ttf"
@@ -18,20 +20,38 @@ font_data = SubResource( 2 )
 content_margin_left = 10.0
 
 [node name="TemplateEnum" type="VBoxContainer"]
-margin_top = 980.0
 margin_right = 1900.0
-margin_bottom = 1030.0
+margin_bottom = 50.0
 custom_constants/separation = 1
 script = ExtResource( 1 )
 
 [node name="VarContent" type="HBoxContainer" parent="."]
 margin_right = 1900.0
-margin_bottom = 33.0
+margin_bottom = 32.0
+
+[node name="HintIcon" type="TextureRect" parent="VarContent"]
+modulate = Color( 0.123871, 0.346745, 0.480469, 1 )
+margin_top = 6.0
+margin_right = 18.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 18, 20 )
+size_flags_horizontal = 0
+size_flags_vertical = 4
+texture = ExtResource( 6 )
+expand = true
+stretch_mode = 6
+script = ExtResource( 5 )
+
+[node name="Control" type="Control" parent="VarContent"]
+margin_left = 22.0
+margin_right = 22.0
+margin_bottom = 32.0
 
 [node name="VarName" type="Label" parent="VarContent"]
+margin_left = 26.0
 margin_top = 6.0
-margin_right = 300.0
-margin_bottom = 27.0
+margin_right = 326.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 300, 0 )
 text = "Description"
 
@@ -47,9 +67,9 @@ theme_type_variation = "LabelCode"
 text = "= null"
 
 [node name="VarValueEnum" type="OptionButton" parent="VarContent"]
-margin_left = 304.0
+margin_left = 330.0
 margin_right = 1871.0
-margin_bottom = 33.0
+margin_bottom = 32.0
 size_flags_horizontal = 3
 text = "Item 0"
 items = [ "Item 0", null, false, 0, null, "Item 1", null, false, 1, null, "Item 2", null, false, 2, null ]
@@ -59,6 +79,7 @@ selected = 0
 modulate = Color( 1, 1, 1, 0.235294 )
 margin_left = 1875.0
 margin_right = 1900.0
+margin_bottom = 32.0
 rect_min_size = Vector2( 25, 25 )
 hint_tooltip = "To null"
 size_flags_vertical = 5
@@ -77,9 +98,9 @@ icon_margin = 3
 
 [node name="Description" type="Label" parent="."]
 modulate = Color( 1, 1, 1, 0.54902 )
-margin_top = 34.0
+margin_top = 33.0
 margin_right = 1900.0
-margin_bottom = 50.0
+margin_bottom = 49.0
 custom_fonts/font = SubResource( 3 )
 custom_styles/normal = SubResource( 7 )
 text = "Description"


### PR DESCRIPTION
Currently the Config Editor crashes when trying to open a benchmark config as it seems the model is still incomplete.
To avoid the Config Editor in crashing the application in such cases, I added a Raw View mode to the Config Editor (available as a Toggle Button at the top which is unlocked if a complete model is found).

When a problem with the model comes up, the Config Editor will automatically open the config in raw mode as a fallback.

![image](https://user-images.githubusercontent.com/9423774/222733667-73ea0372-b324-4b76-9250-4bafd097d4db.png)

![image](https://user-images.githubusercontent.com/9423774/222733703-ea8db70c-9a42-48db-8b16-2513bd1cf3a0.png)

![image](https://user-images.githubusercontent.com/9423774/222733802-3d394cb1-e590-4b93-8fa9-b9f7eac944e1.png)
