### PR TITLE
[Config Editor] Use model to add elements that are not in the request response

### DIFF
--- a/src/components/config/config_templates/component_config_complex.gd
+++ b/src/components/config/config_templates/component_config_complex.gd
@@ -52,6 +52,9 @@ func set_required(_value:bool) -> void:
 
 func set_value(_value) -> void:
 	value = _value
+	for property in model.properties:
+		if not property.name in value:
+			value[property.name] = null
 	if value == null:
 		_on_ButtonSetToNull_pressed()
 	var new_content_elements = config_component.add_element(key, kind, value, self, false)


### PR DESCRIPTION
It was requested that, even if a config request doesn't return some value that is in the model, we should have that field in the config ui so the user can set it.